### PR TITLE
Enforce noCopy on generated structs

### DIFF
--- a/canoto/internal/generate/examples/largest_field_number.canoto.go
+++ b/canoto/internal/generate/examples/largest_field_number.canoto.go
@@ -4,6 +4,7 @@ package examples
 
 import (
 	"io"
+	"sync/atomic"
 	"unicode/utf8"
 
 	"github.com/StephenButtolph/canoto"
@@ -23,6 +24,10 @@ const (
 var _ canoto.Message = (*LargestFieldNumber)(nil)
 
 type canotoData_LargestFieldNumber struct {
+	// Enforce noCopy before atomic usage.
+	// See https://github.com/StephenButtolph/canoto/pull/32
+	_ atomic.Int64
+
 	size int
 }
 

--- a/canoto/internal/generate/examples/scalars.canoto.go
+++ b/canoto/internal/generate/examples/scalars.canoto.go
@@ -4,6 +4,7 @@ package examples
 
 import (
 	"io"
+	"sync/atomic"
 	"unicode/utf8"
 
 	"github.com/StephenButtolph/canoto"
@@ -87,6 +88,10 @@ const (
 var _ canoto.Message = (*Scalars)(nil)
 
 type canotoData_Scalars struct {
+	// Enforce noCopy before atomic usage.
+	// See https://github.com/StephenButtolph/canoto/pull/32
+	_ atomic.Int64
+
 	size int
 	RepeatedInt8Size int
 	RepeatedInt16Size int

--- a/canoto/internal/generate/examples/scalars_test.go
+++ b/canoto/internal/generate/examples/scalars_test.go
@@ -42,7 +42,7 @@ func arrayToSlice[T any](s [][32]T) [][]T {
 	return newS
 }
 
-func canonicalizeCanotoScalars(s Scalars) Scalars {
+func canonicalizeCanotoScalars(s *Scalars) *Scalars {
 	s.Bytes = canonicalizeSlice(s.Bytes)
 	s.RepeatedInt8 = canonicalizeSlice(s.RepeatedInt8)
 	s.RepeatedInt16 = canonicalizeSlice(s.RepeatedInt16)
@@ -178,7 +178,7 @@ func canonicalizeProtoScalars(s *pb.Scalars) *pb.Scalars {
 	}
 }
 
-func canotoScalarsToProto(s Scalars) *pb.Scalars {
+func canotoScalarsToProto(s *Scalars) *pb.Scalars {
 	var largestFieldNumber *pb.LargestFieldNumber
 	if s.LargestFieldNumber.Int32 != 0 {
 		largestFieldNumber = &pb.LargestFieldNumber{
@@ -186,7 +186,9 @@ func canotoScalarsToProto(s Scalars) *pb.Scalars {
 		}
 	}
 	repeatedLargestFieldNumbers := make([]*pb.LargestFieldNumber, len(s.RepeatedLargestFieldNumber))
-	for i, v := range s.RepeatedLargestFieldNumber {
+	for i := range s.RepeatedLargestFieldNumber {
+		v := &s.RepeatedLargestFieldNumber[i]
+
 		repeatedLargestFieldNumbers[i] = &pb.LargestFieldNumber{
 			Int32: v.Int32,
 		}
@@ -195,7 +197,9 @@ func canotoScalarsToProto(s Scalars) *pb.Scalars {
 		fixedLargestFieldNumbers = make([]*pb.LargestFieldNumber, len(s.FixedRepeatedLargestFieldNumber))
 		isZero                   = true
 	)
-	for i, v := range s.FixedRepeatedLargestFieldNumber {
+	for i := range s.FixedRepeatedLargestFieldNumber {
+		v := &s.FixedRepeatedLargestFieldNumber[i]
+
 		fixedLargestFieldNumbers[i] = &pb.LargestFieldNumber{
 			Int32: v.Int32,
 		}
@@ -339,7 +343,7 @@ func FuzzScalars_UnmarshalCanoto(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		require := require.New(t)
 
-		var canotoScalars Scalars
+		canotoScalars := &Scalars{}
 		fz := fuzzer.NewFuzzer(data)
 		fz.Fill(&canotoScalars)
 		canotoScalars = canonicalizeCanotoScalars(canotoScalars)
@@ -350,7 +354,7 @@ func FuzzScalars_UnmarshalCanoto(f *testing.F) {
 			return
 		}
 
-		var canotoScalarsFromProto Scalars
+		canotoScalarsFromProto := &Scalars{}
 		require.NoError(canotoScalarsFromProto.UnmarshalCanoto(pbScalarsBytes))
 		require.Equal(
 			canotoScalars,
@@ -363,7 +367,7 @@ func FuzzScalars_MarshalCanoto(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		require := require.New(t)
 
-		var canotoScalars Scalars
+		canotoScalars := &Scalars{}
 		fz := fuzzer.NewFuzzer(data)
 		fz.Fill(&canotoScalars)
 		canotoScalars = canonicalizeCanotoScalars(canotoScalars)

--- a/canoto/internal/generate/writer.go
+++ b/canoto/internal/generate/writer.go
@@ -19,6 +19,7 @@ package ${package}
 
 import (
 	"io"
+	"sync/atomic"
 	"unicode/utf8"
 
 	"github.com/StephenButtolph/canoto"
@@ -54,6 +55,10 @@ ${tagConstants})
 var _ canoto.Message = (*${structName})(nil)
 
 type canotoData_${structName} struct {
+	// Enforce noCopy before atomic usage.
+	// See https://github.com/StephenButtolph/canoto/pull/32
+	_ atomic.Int64
+
 	size int
 ${cache}}
 


### PR DESCRIPTION
Once go1.24 is released, we will be using `atomic.Int64` values in the `canotoData` structs. This enforces `atomic.noCopy`.

To keep #32 backwards compatible, this PR enforces `atomic.noCopy` now, but does not force the struct to be heap allocated.