### PR TITLE
Add `go:generate` command for `largest_field_number.canoto.go`

### DIFF
--- a/internal/examples/largest_field_number.go
+++ b/internal/examples/largest_field_number.go
@@ -1,3 +1,4 @@
+//go:generate canoto $GOFILE
 //go:generate canoto --proto=true $GOFILE
 
 package examples


### PR DESCRIPTION
`largest_field_number.canoto.go` is not currently auto-generated when using `go generate ./...`