### PR TITLE
Fix parser panic on zero options

### DIFF
--- a/generate/parser.go
+++ b/generate/parser.go
@@ -318,7 +318,7 @@ func parseFieldTag(fs *token.FileSet, field *ast.Field) (
 		)
 	}
 
-	if len(tag.Options) > 2 {
+	if len(tag.Options) > 2 || len(tag.Options) < 1 {
 		return "", 0, "", false, fmt.Errorf("%w %q at %s",
 			errMalformedTag,
 			tag.Value(),


### PR DESCRIPTION
Fixes https://github.com/StephenButtolph/canoto/issues/71

This adds a simple check that the number of tag options must be at least one (in addition to existing check that it cannot be greater than 2).