### PR TITLE
Expand parsing validations

### DIFF
--- a/generate/parser.go
+++ b/generate/parser.go
@@ -10,8 +10,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/StephenButtolph/canoto"
 	"github.com/fatih/structtag"
+
+	"github.com/StephenButtolph/canoto"
 )
 
 const (

--- a/generate/parser.go
+++ b/generate/parser.go
@@ -336,6 +336,12 @@ func parseFieldTag(fs *token.FileSet, field *ast.Field) (
 			fs.Position(field.Pos()),
 		)
 	}
+	if fieldNumber == 0 {
+		return "", 0, "", false, fmt.Errorf("%w 0 at %s",
+			errInvalidFieldNumber,
+			fs.Position(field.Pos()),
+		)
+	}
 	if fieldNumber > canoto.MaxFieldNumber {
 		return "", 0, "", false, fmt.Errorf("%w %d exceeds maximum value of %d at %s",
 			errInvalidFieldNumber,

--- a/generate/parser.go
+++ b/generate/parser.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/StephenButtolph/canoto"
 	"github.com/fatih/structtag"
 )
 
@@ -24,6 +25,7 @@ var (
 	errUnexpectedNumberOfIdentifiers       = errors.New("unexpected number of identifiers")
 	errInvalidGoType                       = errors.New("invalid Go type")
 	errMalformedTag                        = errors.New(`expected "type,fieldNumber[,oneof]" got`)
+	errInvalidFieldNumber                  = errors.New("invalid field number")
 	errRepeatedOneOf                       = errors.New("oneof must not be repeated")
 	errInvalidOneOfName                    = errors.New("invalid oneof name")
 	errStructContainsDuplicateFieldNumbers = errors.New("struct contains duplicate field numbers")
@@ -331,6 +333,14 @@ func parseFieldTag(fs *token.FileSet, field *ast.Field) (
 	if err != nil {
 		return "", 0, "", false, fmt.Errorf("%w at %s",
 			err,
+			fs.Position(field.Pos()),
+		)
+	}
+	if fieldNumber > canoto.MaxFieldNumber {
+		return "", 0, "", false, fmt.Errorf("%w %d exceeds maximum value of %d at %s",
+			errInvalidFieldNumber,
+			fieldNumber,
+			canoto.MaxFieldNumber,
 			fs.Position(field.Pos()),
 		)
 	}

--- a/generate/parser_test.go
+++ b/generate/parser_test.go
@@ -27,6 +27,12 @@ func TestParse(t *testing.T) {
 			wantErr:         errStructContainsDuplicateFieldNumbers,
 		},
 		{
+			name:            "field number 0",
+			filePath:        "testdata/field_number_0.go",
+			wantPackageName: "testdata",
+			wantErr:         errInvalidFieldNumber,
+		},
+		{
 			name:            "field number too large",
 			filePath:        "testdata/field_number_too_large.go",
 			wantPackageName: "testdata",

--- a/generate/parser_test.go
+++ b/generate/parser_test.go
@@ -1,0 +1,52 @@
+package generate
+
+import (
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name string
+
+		filePath     string
+		useAtomic    bool
+		canotoImport string
+
+		wantPackageName string
+		wantMessages    []message
+		wantErr         error
+	}{
+		{
+			name:            "missing field number",
+			filePath:        "testdata/missing_field_number.go",
+			wantPackageName: "testdata",
+			wantErr:         errMalformedTag,
+		},
+		{
+			name:            "repeated oneof",
+			filePath:        "testdata/repeated_oneof.go",
+			wantPackageName: "testdata",
+			wantErr:         errRepeatedOneOf,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
+
+			// Create a new parser
+			fs := token.NewFileSet()
+			f, err := parser.ParseFile(fs, test.filePath, nil, parser.ParseComments)
+			require.NoError(err)
+
+			packageName, messages, err := parse(fs, f, test.useAtomic, test.canotoImport)
+			require.ErrorIs(err, test.wantErr)
+			require.Equal(test.wantPackageName, packageName)
+			require.Equal(test.wantMessages, messages)
+		})
+	}
+}

--- a/generate/parser_test.go
+++ b/generate/parser_test.go
@@ -21,6 +21,18 @@ func TestParse(t *testing.T) {
 		wantErr         error
 	}{
 		{
+			name:            "duplicate field number",
+			filePath:        "testdata/duplicate_field_number.go",
+			wantPackageName: "testdata",
+			wantErr:         errStructContainsDuplicateFieldNumbers,
+		},
+		{
+			name:            "field number too large",
+			filePath:        "testdata/field_number_too_large.go",
+			wantPackageName: "testdata",
+			wantErr:         errInvalidFieldNumber,
+		},
+		{
 			name:            "missing field number",
 			filePath:        "testdata/missing_field_number.go",
 			wantPackageName: "testdata",

--- a/generate/testdata/duplicate_field_number.go
+++ b/generate/testdata/duplicate_field_number.go
@@ -1,0 +1,6 @@
+package testdata
+
+type duplicateFieldNumber struct {
+	IntA int64 `canoto:"int,1"`
+	IntB int64 `canoto:"int,1"`
+}

--- a/generate/testdata/field_number_0.go
+++ b/generate/testdata/field_number_0.go
@@ -1,0 +1,5 @@
+package testdata
+
+type fieldNumber0 struct {
+	Int int64 `canoto:"int,0"`
+}

--- a/generate/testdata/field_number_too_large.go
+++ b/generate/testdata/field_number_too_large.go
@@ -1,0 +1,5 @@
+package testdata
+
+type fieldNumberTooLarge struct {
+	Int int64 `canoto:"int,536870912"`
+}

--- a/generate/testdata/missing_field_number.go
+++ b/generate/testdata/missing_field_number.go
@@ -1,0 +1,5 @@
+package testdata
+
+type missingFieldNumber struct {
+	Int int64 `canoto:"int"`
+}

--- a/generate/testdata/repeated_oneof.go
+++ b/generate/testdata/repeated_oneof.go
@@ -1,0 +1,5 @@
+package testdata
+
+type repeatedOneOf struct {
+	Ints []int64 `canoto:"repeated int,1,int"`
+}


### PR DESCRIPTION
From the Proto spec:
> You then add your oneof fields to the oneof definition. You can add fields of any type, except map fields and repeated fields. If you need to add a repeated field to a oneof, you can use a message containing the repeated field.

Previously it was possible to specify things like ``canoto:"repeated int,1,A"`` which after generating the `.proto` file would have encountered errors such as: `syntax error: unexpected "repeated"`