### PR TITLE
Replace `--concurrent` flag with `noatomic` tag

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -139,7 +139,7 @@ linters-settings:
         - ["t.Logf[0]", "/.*%.*/", "no format directive, use t.Log instead"]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#struct-tag
       - name: struct-tag
-        disabled: false
+        disabled: true
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unexported-naming
       - name: unexported-naming
         disabled: false

--- a/README.md
+++ b/README.md
@@ -195,6 +195,24 @@ var _ canoto.Message = (*GenericField[BadUsage])(nil)
 
 Because `BadUsage` is an interface, it does not have a useful zero value and will panic when `GenericField` attempts to call its methods.
 
+### Pass-By-Value Messages
+
+By default, the auto-generated `canotoData` struct includes atomic variables. This ensures that `MarshalCanoto` can be called at the same time on multiple threads, which is expected for what appears to be a read only method.
+
+However, this results in being unable to pass messages by value due to the [NoCopy](https://github.com/golang/go/issues/8005) included on atomic variables.
+
+If concurrent calls to `MarshalCanoto` are not required and it is desired to be able to pass a message by value, the `canoto:"noatomic"` tag can be added to the `canotoData` field to remove the usage of atomic variables.
+
+For example:
+
+```golang
+type PassableByValue struct {
+	Int int64 `canoto:"int,1"`
+
+	canotoData canotoData_PassableByValue `canoto:"noatomic"`
+}
+```
+
 ### Standalone Implementations
 
 In some instances, it may be desirable for the generated code to avoid introducing the dependency on this repo into the `go.mod` file. As an example, if the user must support having multiple versions of canoto utilized in the same application.

--- a/canoto/main.go
+++ b/canoto/main.go
@@ -12,12 +12,11 @@ import (
 )
 
 const (
-	canotoFlag     = "canoto"
-	libraryFlag    = "library"
-	protoFlag      = "proto"
-	versionFlag    = "version"
-	concurrentFlag = "concurrent"
-	importFlag     = "import"
+	canotoFlag  = "canoto"
+	libraryFlag = "library"
+	protoFlag   = "proto"
+	versionFlag = "version"
+	importFlag  = "import"
 )
 
 func init() {
@@ -58,11 +57,6 @@ func main() {
 				return fmt.Errorf("failed to get proto flag: %w", err)
 			}
 
-			useAtomic, err := flags.GetBool(concurrentFlag)
-			if err != nil {
-				return fmt.Errorf("failed to get proto flag: %w", err)
-			}
-
 			canotoImport, err := flags.GetString(importFlag)
 			if err != nil {
 				return fmt.Errorf("failed to get import flag: %w", err)
@@ -71,7 +65,7 @@ func main() {
 
 			for _, arg := range args {
 				if canoto {
-					if err := generate.Canoto(arg, useAtomic, canotoImport); err != nil {
+					if err := generate.Canoto(arg, canotoImport); err != nil {
 						return fmt.Errorf("failed to generate canoto for %q: %w", arg, err)
 					}
 				}
@@ -90,7 +84,6 @@ func main() {
 	flags.Bool(canotoFlag, true, "Generate canoto file")
 	flags.String(libraryFlag, "", "Generate the canoto library in the specified directory")
 	flags.Bool(protoFlag, false, "Generate proto file")
-	flags.Bool(concurrentFlag, true, "Generate canoto serialization that is safe for concurrent access")
 	flags.String(importFlag, "github.com/StephenButtolph/canoto", "Package to depend on for canoto serialization primitives")
 
 	if err := cmd.Execute(); err != nil {

--- a/generate/canoto.go
+++ b/generate/canoto.go
@@ -26,7 +26,6 @@ var errNonGoExtension = errors.New("file must be a go file")
 // Canoto generates the canoto serialization logic for the provided file.
 func Canoto(
 	inputFilePath string,
-	useAtomic bool,
 	canotoImport string,
 ) error {
 	var outputFilePath string
@@ -46,7 +45,7 @@ func Canoto(
 		return err
 	}
 
-	packageName, messages, err := parse(fs, f, useAtomic, canotoImport)
+	packageName, messages, err := parse(fs, f, canotoImport)
 	if err != nil {
 		return err
 	}

--- a/generate/parser_test.go
+++ b/generate/parser_test.go
@@ -13,7 +13,6 @@ func TestParse(t *testing.T) {
 		name string
 
 		filePath     string
-		useAtomic    bool
 		canotoImport string
 
 		wantPackageName string
@@ -61,7 +60,7 @@ func TestParse(t *testing.T) {
 			f, err := parser.ParseFile(fs, test.filePath, nil, parser.ParseComments)
 			require.NoError(err)
 
-			packageName, messages, err := parse(fs, f, test.useAtomic, test.canotoImport)
+			packageName, messages, err := parse(fs, f, test.canotoImport)
 			require.ErrorIs(err, test.wantErr)
 			require.Equal(test.wantPackageName, packageName)
 			require.Equal(test.wantMessages, messages)

--- a/generate/proto.go
+++ b/generate/proto.go
@@ -31,7 +31,7 @@ func Proto(
 		return err
 	}
 
-	packageName, messages, err := parse(fs, f, false /*=useAtomic*/, canotoImport)
+	packageName, messages, err := parse(fs, f, canotoImport)
 	if err != nil {
 		return err
 	}

--- a/internal/inlined_canoto.go
+++ b/internal/inlined_canoto.go
@@ -1,4 +1,4 @@
-//go:generate canoto --concurrent=false --library=./ --import=github.com/StephenButtolph/canoto/internal/canoto $GOFILE
+//go:generate canoto --library=./ --import=github.com/StephenButtolph/canoto/internal/canoto $GOFILE
 
 package examples
 
@@ -14,5 +14,5 @@ var (
 type justAnInt struct {
 	Int8 int8 `canoto:"int,1"`
 
-	canotoData canotoData_justAnInt
+	canotoData canotoData_justAnInt `canoto:"noatomic"`
 }


### PR DESCRIPTION
Resolves #76

`--concurrent` enforced that the whole file opt in or out of the atomic variables. Additionally, the `--concurrent` flag was harder to discover being just in the CLI rather than being documented in the README.md