### PR TITLE
Update to go1.23

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,6 +44,7 @@ linters:
     - err113
     - errcheck
     - errorlint
+    - exptostd
     - forbidigo
     - gci
     - gocritic

--- a/canoto.go
+++ b/canoto.go
@@ -726,7 +726,7 @@ func FieldTypeFromField[T Field](
 		fieldType = reflect.TypeOf(field).Elem()
 	)
 	if index := slices.Index(types, fieldType); index >= 0 {
-		f.TypeRecursive = uint64(len(types) - index) //nolint:gosec // disable G115
+		f.TypeRecursive = uint64(len(types) - index) //#nosec G115 // False positive
 	} else {
 		f.TypeMessage = field.CanotoSpec(types...)
 		// If this does not have a valid spec, it is treated as bytes.
@@ -1240,7 +1240,7 @@ func (f *FieldType) unmarshalFixedBytes(r *Reader, _ []*Spec) (any, error) {
 		if err != nil {
 			return nil, err
 		}
-		count = uint64(countMinus1 + 1) //nolint:gosec // disable G115
+		count = uint64(countMinus1 + 1) //#nosec G115 // False positive
 	}
 
 	values := make([][]byte, count)
@@ -1396,7 +1396,7 @@ func unmarshalPackedVarint[T comparable](
 		if len(msgBytes) == 0 {
 			return nil, ErrZeroValue
 		}
-		count = uint64(CountInts(msgBytes)) //nolint:gosec // disable G115
+		count = uint64(CountInts(msgBytes)) //#nosec G115 // False positive
 	}
 	values := make([]T, count)
 	r = &Reader{
@@ -1544,7 +1544,7 @@ func unmarshalUnpacked[T any](
 		if err != nil {
 			return nil, err
 		}
-		count = uint64(countMinus1 + 1) //nolint:gosec // disable G115
+		count = uint64(countMinus1 + 1) //#nosec G115 // False positive
 	}
 
 	values := make([]T, count)

--- a/canoto.go
+++ b/canoto.go
@@ -726,7 +726,7 @@ func FieldTypeFromField[T Field](
 		fieldType = reflect.TypeOf(field).Elem()
 	)
 	if index := slices.Index(types, fieldType); index >= 0 {
-		f.TypeRecursive = uint64(len(types) - index)
+		f.TypeRecursive = uint64(len(types) - index) //nolint:gosec // disable G115
 	} else {
 		f.TypeMessage = field.CanotoSpec(types...)
 		// If this does not have a valid spec, it is treated as bytes.
@@ -1240,7 +1240,7 @@ func (f *FieldType) unmarshalFixedBytes(r *Reader, _ []*Spec) (any, error) {
 		if err != nil {
 			return nil, err
 		}
-		count = uint64(countMinus1 + 1)
+		count = uint64(countMinus1 + 1) //nolint:gosec // disable G115
 	}
 
 	values := make([][]byte, count)
@@ -1396,7 +1396,7 @@ func unmarshalPackedVarint[T comparable](
 		if len(msgBytes) == 0 {
 			return nil, ErrZeroValue
 		}
-		count = uint64(CountInts(msgBytes))
+		count = uint64(CountInts(msgBytes)) //nolint:gosec // disable G115
 	}
 	values := make([]T, count)
 	r = &Reader{
@@ -1544,7 +1544,7 @@ func unmarshalUnpacked[T any](
 		if err != nil {
 			return nil, err
 		}
-		count = uint64(countMinus1 + 1)
+		count = uint64(countMinus1 + 1) //nolint:gosec // disable G115
 	}
 
 	values := make([]T, count)

--- a/generate/message.go
+++ b/generate/message.go
@@ -1,9 +1,8 @@
 package generate
 
 import (
+	"maps"
 	"slices"
-
-	"golang.org/x/exp/maps"
 )
 
 type message struct {
@@ -22,7 +21,5 @@ func (m *message) OneOfs() []string {
 		}
 	}
 
-	oneOfsSlice := maps.Keys(oneOfs)
-	slices.Sort(oneOfsSlice)
-	return oneOfsSlice
+	return slices.Sorted(maps.Keys(oneOfs))
 }

--- a/go.mod
+++ b/go.mod
@@ -1,18 +1,18 @@
 module github.com/StephenButtolph/canoto
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/fatih/structtag v1.2.0
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.10.0
 	github.com/thepudds/fzgen v0.4.3
-	golang.org/x/exp v0.0.0-20241215155358-4a5509556b9e
 	google.golang.org/protobuf v1.35.2
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sanity-io/litter v1.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,6 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/thepudds/fzgen v0.4.3 h1:srUP/34BulQaEwPP/uHZkdjUcUjIzL7Jkf4CBVryiP8=
 github.com/thepudds/fzgen v0.4.3/go.mod h1:BhhwtRhzgvLWAjjcHDJ9pEiLD2Z9hrVIFjBCHJ//zJ4=
-golang.org/x/exp v0.0.0-20241215155358-4a5509556b9e h1:4qufH0hlUYs6AO6XmZC3GqfDPGSXHVXUFR6OND+iJX4=
-golang.org/x/exp v0.0.0-20241215155358-4a5509556b9e/go.mod h1:qj5a5QZpwLU2NLQudwIN5koi3beDhSAlJwa67PuM98c=
 google.golang.org/protobuf v1.35.2 h1:8Ar7bF+apOIoThw1EdZl0p1oWvMqTHmpA2fRTyZO8io=
 google.golang.org/protobuf v1.35.2/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/internal/canoto/canoto.go
+++ b/internal/canoto/canoto.go
@@ -728,7 +728,7 @@ func FieldTypeFromField[T Field](
 		fieldType = reflect.TypeOf(field).Elem()
 	)
 	if index := slices.Index(types, fieldType); index >= 0 {
-		f.TypeRecursive = uint64(len(types) - index)
+		f.TypeRecursive = uint64(len(types) - index) //#nosec G115 // False positive
 	} else {
 		f.TypeMessage = field.CanotoSpec(types...)
 		// If this does not have a valid spec, it is treated as bytes.
@@ -1242,7 +1242,7 @@ func (f *FieldType) unmarshalFixedBytes(r *Reader, _ []*Spec) (any, error) {
 		if err != nil {
 			return nil, err
 		}
-		count = uint64(countMinus1 + 1)
+		count = uint64(countMinus1 + 1) //#nosec G115 // False positive
 	}
 
 	values := make([][]byte, count)
@@ -1398,7 +1398,7 @@ func unmarshalPackedVarint[T comparable](
 		if len(msgBytes) == 0 {
 			return nil, ErrZeroValue
 		}
-		count = uint64(CountInts(msgBytes))
+		count = uint64(CountInts(msgBytes)) //#nosec G115 // False positive
 	}
 	values := make([]T, count)
 	r = &Reader{
@@ -1546,7 +1546,7 @@ func unmarshalUnpacked[T any](
 		if err != nil {
 			return nil, err
 		}
-		count = uint64(countMinus1 + 1)
+		count = uint64(countMinus1 + 1) //#nosec G115 // False positive
 	}
 
 	values := make([]T, count)

--- a/internal/canoto_test.go
+++ b/internal/canoto_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/thepudds/fzgen/fuzzer"
-	"golang.org/x/exp/constraints"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
@@ -22,7 +21,7 @@ func canonicalizeSlice[T any](s []T) []T {
 	return s
 }
 
-func castSlice[I, O constraints.Integer](s []I) []O {
+func castSlice[I ~int8 | ~int16 | ~uint8 | ~uint16, O ~int32 | ~uint32](s []I) []O {
 	if len(s) == 0 {
 		return nil
 	}

--- a/scripts/lint-golang.sh
+++ b/scripts/lint-golang.sh
@@ -7,6 +7,6 @@ if ! [[ "$0" =~ scripts/lint-golang.sh ]]; then
   exit 255
 fi
 
-go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
+go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.0
 
 golangci-lint run --config .golangci.yml ./...


### PR DESCRIPTION
Per the Go [release policy](https://go.dev/doc/devel/release#policy), go1.22 is no longer supported.

This PR updates to go1.23, removes the dependency on `golang.org/x/exp`, and adds the `exptostd` linter.