### PR TITLE
Precalculate tag sizes

### DIFF
--- a/canoto.go
+++ b/canoto.go
@@ -328,8 +328,11 @@ func Append[T Bytes](w *Writer, v T) {
 // This function should not typically be used during marshaling, as tags can be
 // precomputed.
 func Tag(fieldNumber uint32, wireType WireType) []byte {
-	w := Writer{}
-	AppendUint(&w, fieldNumber<<wireTypeLength|uint32(wireType))
+	tag := fieldNumber<<wireTypeLength | uint32(wireType)
+	w := Writer{
+		make([]byte, 0, SizeUint(tag)),
+	}
+	AppendUint(&w, tag)
 	return w.B
 }
 

--- a/canoto_test.go
+++ b/canoto_test.go
@@ -37,6 +37,18 @@ func (v invalidTest) Bytes(t *testing.T) []byte {
 	return bytes
 }
 
+func BenchmarkTag(b *testing.B) {
+	for i := 1; i < 30; i++ {
+		fieldNumber := uint32(1)<<i - 1
+		fieldNumberStr := strconv.FormatUint(uint64(fieldNumber), 10)
+		b.Run(fieldNumberStr, func(b *testing.B) {
+			for range b.N {
+				Tag(fieldNumber, Varint)
+			}
+		})
+	}
+}
+
 func TestReadTag(t *testing.T) {
 	type tag struct {
 		fieldNumber uint32

--- a/canoto_test.go
+++ b/canoto_test.go
@@ -38,8 +38,11 @@ func (v invalidTest) Bytes(t *testing.T) []byte {
 }
 
 func BenchmarkTag(b *testing.B) {
-	for i := 1; i < 30; i++ {
-		fieldNumber := uint32(1)<<i - 1
+	fieldNumbers := []uint32{
+		1,
+		MaxFieldNumber,
+	}
+	for _, fieldNumber := range fieldNumbers {
 		fieldNumberStr := strconv.FormatUint(uint64(fieldNumber), 10)
 		b.Run(fieldNumberStr, func(b *testing.B) {
 			for range b.N {

--- a/internal/canoto/canoto.go
+++ b/internal/canoto/canoto.go
@@ -330,8 +330,11 @@ func Append[T Bytes](w *Writer, v T) {
 // This function should not typically be used during marshaling, as tags can be
 // precomputed.
 func Tag(fieldNumber uint32, wireType WireType) []byte {
-	w := Writer{}
-	AppendUint(&w, fieldNumber<<wireTypeLength|uint32(wireType))
+	tag := fieldNumber<<wireTypeLength | uint32(wireType)
+	w := Writer{
+		make([]byte, 0, SizeUint(tag)),
+	}
+	AppendUint(&w, tag)
 	return w.B
 }
 


### PR DESCRIPTION
`Tag` isn't called in the primary serialization path, but I want buffers to be precalculated where possible.