### PR TITLE
Avoid string allocations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ go.work.sum
 
 # env file
 .env
+
+# vscode directory
+.vscode

--- a/canoto.go
+++ b/canoto.go
@@ -505,7 +505,7 @@ func SizeBytes[T Bytes](v T) uint64 {
 
 // CountBytes counts the consecutive number of length-prefixed fields with the
 // given tag.
-func CountBytes(bytes []byte, tag string) (uint64, error) {
+func CountBytes[T Bytes](bytes []byte, tag T) (uint64, error) {
 	var (
 		r     = Reader{B: bytes}
 		count uint64
@@ -526,8 +526,8 @@ func CountBytes(bytes []byte, tag string) (uint64, error) {
 }
 
 // HasPrefix returns true if the bytes start with the given prefix.
-func HasPrefix(bytes []byte, prefix string) bool {
-	return len(bytes) >= len(prefix) && string(bytes[:len(prefix)]) == prefix
+func HasPrefix[T Bytes](bytes []byte, prefix T) bool {
+	return len(bytes) >= len(prefix) && string(bytes[:len(prefix)]) == string(prefix)
 }
 
 // ReadString reads a string from the reader. The string is verified to be valid
@@ -1268,7 +1268,7 @@ func (f *FieldType) unmarshalFixedBytes(r *Reader, _ []*Spec) (any, error) {
 
 	count := f.FixedLength
 	if count == 0 {
-		countMinus1, err := CountBytes(r.B, string(expectedTag))
+		countMinus1, err := CountBytes(r.B, expectedTag)
 		if err != nil {
 			return nil, err
 		}
@@ -1282,7 +1282,7 @@ func (f *FieldType) unmarshalFixedBytes(r *Reader, _ []*Spec) (any, error) {
 
 	// Read the rest of the entries, stripping the tag each time.
 	for i := range count - 1 {
-		if !HasPrefix(r.B, string(expectedTag)) {
+		if !HasPrefix(r.B, expectedTag) {
 			return nil, ErrUnknownField
 		}
 		r.B = r.B[len(expectedTag):]
@@ -1572,7 +1572,7 @@ func unmarshalUnpacked[T any](
 
 	count := f.FixedLength
 	if count == 0 {
-		countMinus1, err := CountBytes(r.B, string(expectedTag))
+		countMinus1, err := CountBytes(r.B, expectedTag)
 		if err != nil {
 			return nil, err
 		}
@@ -1589,7 +1589,7 @@ func unmarshalUnpacked[T any](
 
 	// Read the rest of the entries, stripping the tag each time.
 	for i := range count - 1 {
-		if !HasPrefix(r.B, string(expectedTag)) {
+		if !HasPrefix(r.B, expectedTag) {
 			return nil, ErrUnknownField
 		}
 		r.B = r.B[len(expectedTag):]

--- a/canoto_test.go
+++ b/canoto_test.go
@@ -37,6 +37,23 @@ func (v invalidTest) Bytes(t *testing.T) []byte {
 	return bytes
 }
 
+func BenchmarkHasPrefix(b *testing.B) {
+	bytes := []byte("hello")
+	prefixes := [][]byte{
+		[]byte("hel"),
+		// golang allocates string conversions on the stack if they are <= 32 bytes
+		[]byte("helloooooooooooooooooooooooooooo"),
+		[]byte("hellooooooooooooooooooooooooooooo"),
+	}
+	for _, prefix := range prefixes {
+		b.Run(string(prefix), func(b *testing.B) {
+			for range b.N {
+				HasPrefix(bytes, prefix)
+			}
+		})
+	}
+}
+
 func TestReadTag(t *testing.T) {
 	type tag struct {
 		fieldNumber uint32

--- a/canoto_test.go
+++ b/canoto_test.go
@@ -36,6 +36,7 @@ func (v invalidTest) Bytes(t *testing.T) []byte {
 	require.NoError(t, err)
 	return bytes
 }
+
 func BenchmarkTag(b *testing.B) {
 	fieldNumbers := []uint32{
 		1,

--- a/internal/canoto/canoto.go
+++ b/internal/canoto/canoto.go
@@ -507,7 +507,7 @@ func SizeBytes[T Bytes](v T) uint64 {
 
 // CountBytes counts the consecutive number of length-prefixed fields with the
 // given tag.
-func CountBytes(bytes []byte, tag string) (uint64, error) {
+func CountBytes[T Bytes](bytes []byte, tag T) (uint64, error) {
 	var (
 		r     = Reader{B: bytes}
 		count uint64
@@ -528,8 +528,8 @@ func CountBytes(bytes []byte, tag string) (uint64, error) {
 }
 
 // HasPrefix returns true if the bytes start with the given prefix.
-func HasPrefix(bytes []byte, prefix string) bool {
-	return len(bytes) >= len(prefix) && string(bytes[:len(prefix)]) == prefix
+func HasPrefix[T Bytes](bytes []byte, prefix T) bool {
+	return len(bytes) >= len(prefix) && string(bytes[:len(prefix)]) == string(prefix)
 }
 
 // ReadString reads a string from the reader. The string is verified to be valid
@@ -1270,7 +1270,7 @@ func (f *FieldType) unmarshalFixedBytes(r *Reader, _ []*Spec) (any, error) {
 
 	count := f.FixedLength
 	if count == 0 {
-		countMinus1, err := CountBytes(r.B, string(expectedTag))
+		countMinus1, err := CountBytes(r.B, expectedTag)
 		if err != nil {
 			return nil, err
 		}
@@ -1284,7 +1284,7 @@ func (f *FieldType) unmarshalFixedBytes(r *Reader, _ []*Spec) (any, error) {
 
 	// Read the rest of the entries, stripping the tag each time.
 	for i := range count - 1 {
-		if !HasPrefix(r.B, string(expectedTag)) {
+		if !HasPrefix(r.B, expectedTag) {
 			return nil, ErrUnknownField
 		}
 		r.B = r.B[len(expectedTag):]
@@ -1574,7 +1574,7 @@ func unmarshalUnpacked[T any](
 
 	count := f.FixedLength
 	if count == 0 {
-		countMinus1, err := CountBytes(r.B, string(expectedTag))
+		countMinus1, err := CountBytes(r.B, expectedTag)
 		if err != nil {
 			return nil, err
 		}
@@ -1591,7 +1591,7 @@ func unmarshalUnpacked[T any](
 
 	// Read the rest of the entries, stripping the tag each time.
 	for i := range count - 1 {
-		if !HasPrefix(r.B, string(expectedTag)) {
+		if !HasPrefix(r.B, expectedTag) {
 			return nil, ErrUnknownField
 		}
 		r.B = r.B[len(expectedTag):]


### PR DESCRIPTION
The go compiler includes optimizations specifically for when a `[]byte` is cast to a `string` in a read-only way. This PR moves the casts from `[]byte` to `string` so that the compiler has a better chance at being able to optimize the conversion.

With the added benchmarks, the new code does not perform allocations 🚀.