### PR TITLE
Test that multiple fields per type is disallowed

### DIFF
--- a/generate/parser_test.go
+++ b/generate/parser_test.go
@@ -51,6 +51,12 @@ func TestParse(t *testing.T) {
 			wantErr:         errMalformedTag,
 		},
 		{
+			name:            "multiple fields per type",
+			filePath:        "testdata/multiple_fields_per_type.go",
+			wantPackageName: "testdata",
+			wantErr:         errUnexpectedNumberOfIdentifiers,
+		},
+		{
 			name:            "repeated oneof",
 			filePath:        "testdata/repeated_oneof.go",
 			wantPackageName: "testdata",

--- a/generate/testdata/multiple_fields_per_type.go
+++ b/generate/testdata/multiple_fields_per_type.go
@@ -1,0 +1,5 @@
+package testdata
+
+type multipleFieldsPerType struct {
+	A, B int64 `canoto:"int,1"`
+}


### PR DESCRIPTION
Adding this test just to canonicalize the behavior as invalid.