### PR TITLE
Use switches for oneofs in `MarshalCanotoInto`

### DIFF
--- a/canoto.canoto.go
+++ b/canoto.canoto.go
@@ -887,7 +887,8 @@ func (c *FieldType) MarshalCanotoInto(w Writer) Writer {
 		Append(&w, canoto__FieldType__OneOf__tag)
 		AppendBytes(&w, c.OneOf)
 	}
-	switch c.CachedWhichOneOfType() {
+	cachedWhichOneOfType := atomic.LoadUint32(&c.canotoData.TypeOneOf)
+	switch cachedWhichOneOfType {
 	case 6:
 		Append(&w, canoto__FieldType__TypeInt__tag)
 		AppendUint(&w, c.TypeInt)

--- a/canoto.canoto.go
+++ b/canoto.canoto.go
@@ -3,7 +3,9 @@
 // 	canoto v0.17.1
 // source: canoto.go
 
+
 package canoto
+
 
 import (
 	"io"
@@ -11,21 +13,26 @@ import (
 	"sync/atomic"
 )
 
+
 // Ensure that unused imports do not error
 var (
 	_ atomic.Uint64
 
+
 	_ = io.ErrUnexpectedEOF
 )
+
 
 const (
 	canoto__Spec__Name__tag   = "\x0a" // canoto.Tag(1, canoto.Len)
 	canoto__Spec__Fields__tag = "\x12" // canoto.Tag(2, canoto.Len)
 )
 
+
 type canotoData_Spec struct {
 	size uint64
 }
+
 
 // CanotoSpec returns the specification of this canoto message.
 func (*Spec) CanotoSpec(types ...reflect.Type) *Spec {
@@ -55,10 +62,12 @@ func (*Spec) CanotoSpec(types ...reflect.Type) *Spec {
 	return s
 }
 
+
 // MakeCanoto creates a new empty value.
 func (*Spec) MakeCanoto() *Spec {
 	return new(Spec)
 }
+
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -69,6 +78,7 @@ func (c *Spec) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
+
 
 // UnmarshalCanotoFrom populates the struct from a [Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -81,6 +91,7 @@ func (c *Spec) UnmarshalCanotoFrom(r Reader) error {
 	*c = Spec{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
+
 	var minField uint32
 	for HasNext(&r) {
 		field, wireType, err := ReadTag(&r)
@@ -90,6 +101,7 @@ func (c *Spec) UnmarshalCanotoFrom(r Reader) error {
 		if field < minField {
 			return ErrInvalidFieldOrder
 		}
+
 
 		switch field {
 		case 1:
@@ -159,10 +171,12 @@ func (c *Spec) UnmarshalCanotoFrom(r Reader) error {
 			return ErrUnknownField
 		}
 
+
 		minField = field + 1
 	}
 	return nil
 }
+
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -189,6 +203,7 @@ func (c *Spec) ValidCanoto() bool {
 	return true
 }
 
+
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
 //
@@ -212,6 +227,7 @@ func (c *Spec) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
+
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -226,6 +242,7 @@ func (c *Spec) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
+
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -239,6 +256,7 @@ func (c *Spec) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
+
 
 // MarshalCanotoInto writes the struct into a [Writer] and returns the
 // resulting [Writer]. Most users should just use MarshalCanoto.
@@ -268,6 +286,7 @@ func (c *Spec) MarshalCanotoInto(w Writer) Writer {
 	return w
 }
 
+
 const (
 	canoto__FieldType__FieldNumber__tag    = "\x08" // canoto.Tag(1, canoto.Varint)
 	canoto__FieldType__Name__tag           = "\x12" // canoto.Tag(2, canoto.Len)
@@ -286,11 +305,13 @@ const (
 	canoto__FieldType__TypeMessage__tag    = "\x7a" // canoto.Tag(15, canoto.Len)
 )
 
+
 type canotoData_FieldType struct {
 	size uint64
 
 	TypeOneOf uint32
 }
+
 
 // CanotoSpec returns the specification of this canoto message.
 func (*FieldType) CanotoSpec(types ...reflect.Type) *Spec {
@@ -398,10 +419,12 @@ func (*FieldType) CanotoSpec(types ...reflect.Type) *Spec {
 	return s
 }
 
+
 // MakeCanoto creates a new empty value.
 func (*FieldType) MakeCanoto() *FieldType {
 	return new(FieldType)
 }
+
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -412,6 +435,7 @@ func (c *FieldType) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
+
 
 // UnmarshalCanotoFrom populates the struct from a [Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -424,6 +448,7 @@ func (c *FieldType) UnmarshalCanotoFrom(r Reader) error {
 	*c = FieldType{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
+
 	var minField uint32
 	for HasNext(&r) {
 		field, wireType, err := ReadTag(&r)
@@ -433,6 +458,7 @@ func (c *FieldType) UnmarshalCanotoFrom(r Reader) error {
 		if field < minField {
 			return ErrInvalidFieldOrder
 		}
+
 
 		switch field {
 		case 1:
@@ -648,10 +674,12 @@ func (c *FieldType) UnmarshalCanotoFrom(r Reader) error {
 			return ErrUnknownField
 		}
 
+
 		minField = field + 1
 	}
 	return nil
 }
+
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -740,6 +768,7 @@ func (c *FieldType) ValidCanoto() bool {
 	return true
 }
 
+
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
 //
@@ -812,6 +841,7 @@ func (c *FieldType) CalculateCanotoCache() {
 	atomic.StoreUint32(&c.canotoData.TypeOneOf, TypeOneOf)
 }
 
+
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -840,6 +870,7 @@ func (c *FieldType) CachedWhichOneOfType() uint32 {
 	return atomic.LoadUint32(&c.canotoData.TypeOneOf)
 }
 
+
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -853,6 +884,7 @@ func (c *FieldType) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
+
 
 // MarshalCanotoInto writes the struct into a [Writer] and returns the
 // resulting [Writer]. Most users should just use MarshalCanoto.
@@ -887,48 +919,39 @@ func (c *FieldType) MarshalCanotoInto(w Writer) Writer {
 		Append(&w, canoto__FieldType__OneOf__tag)
 		AppendBytes(&w, c.OneOf)
 	}
-	if !IsZero(c.TypeInt) {
+	switch c.CachedWhichOneOfType() {
+	case 6:
 		Append(&w, canoto__FieldType__TypeInt__tag)
 		AppendUint(&w, c.TypeInt)
-	}
-	if !IsZero(c.TypeUint) {
+	case 7:
 		Append(&w, canoto__FieldType__TypeUint__tag)
 		AppendUint(&w, c.TypeUint)
-	}
-	if !IsZero(c.TypeFixedInt) {
+	case 8:
 		Append(&w, canoto__FieldType__TypeFixedInt__tag)
 		AppendUint(&w, c.TypeFixedInt)
-	}
-	if !IsZero(c.TypeFixedUint) {
+	case 9:
 		Append(&w, canoto__FieldType__TypeFixedUint__tag)
 		AppendUint(&w, c.TypeFixedUint)
-	}
-	if !IsZero(c.TypeBool) {
+	case 10:
 		Append(&w, canoto__FieldType__TypeBool__tag)
 		AppendBool(&w, true)
-	}
-	if !IsZero(c.TypeString) {
+	case 11:
 		Append(&w, canoto__FieldType__TypeString__tag)
 		AppendBool(&w, true)
-	}
-	if !IsZero(c.TypeBytes) {
+	case 12:
 		Append(&w, canoto__FieldType__TypeBytes__tag)
 		AppendBool(&w, true)
-	}
-	if !IsZero(c.TypeFixedBytes) {
+	case 13:
 		Append(&w, canoto__FieldType__TypeFixedBytes__tag)
 		AppendUint(&w, c.TypeFixedBytes)
-	}
-	if !IsZero(c.TypeRecursive) {
+	case 14:
 		Append(&w, canoto__FieldType__TypeRecursive__tag)
 		AppendUint(&w, c.TypeRecursive)
-	}
-	if c.TypeMessage != nil {
-		if fieldSize := (c.TypeMessage).CachedCanotoSize(); fieldSize != 0 {
-			Append(&w, canoto__FieldType__TypeMessage__tag)
-			AppendUint(&w, fieldSize)
-			w = (c.TypeMessage).MarshalCanotoInto(w)
-		}
+	case 15:
+		fieldSize := (c.TypeMessage).CachedCanotoSize()
+		Append(&w, canoto__FieldType__TypeMessage__tag)
+		AppendUint(&w, fieldSize)
+		w = (c.TypeMessage).MarshalCanotoInto(w)
 	}
 	return w
 }

--- a/canoto.canoto.go
+++ b/canoto.canoto.go
@@ -3,9 +3,7 @@
 // 	canoto v0.17.1
 // source: canoto.go
 
-
 package canoto
-
 
 import (
 	"io"
@@ -13,26 +11,21 @@ import (
 	"sync/atomic"
 )
 
-
 // Ensure that unused imports do not error
 var (
 	_ atomic.Uint64
 
-
 	_ = io.ErrUnexpectedEOF
 )
-
 
 const (
 	canoto__Spec__Name__tag   = "\x0a" // canoto.Tag(1, canoto.Len)
 	canoto__Spec__Fields__tag = "\x12" // canoto.Tag(2, canoto.Len)
 )
 
-
 type canotoData_Spec struct {
 	size uint64
 }
-
 
 // CanotoSpec returns the specification of this canoto message.
 func (*Spec) CanotoSpec(types ...reflect.Type) *Spec {
@@ -62,12 +55,10 @@ func (*Spec) CanotoSpec(types ...reflect.Type) *Spec {
 	return s
 }
 
-
 // MakeCanoto creates a new empty value.
 func (*Spec) MakeCanoto() *Spec {
 	return new(Spec)
 }
-
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -78,7 +69,6 @@ func (c *Spec) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
-
 
 // UnmarshalCanotoFrom populates the struct from a [Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -91,7 +81,6 @@ func (c *Spec) UnmarshalCanotoFrom(r Reader) error {
 	*c = Spec{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
-
 	var minField uint32
 	for HasNext(&r) {
 		field, wireType, err := ReadTag(&r)
@@ -101,7 +90,6 @@ func (c *Spec) UnmarshalCanotoFrom(r Reader) error {
 		if field < minField {
 			return ErrInvalidFieldOrder
 		}
-
 
 		switch field {
 		case 1:
@@ -171,12 +159,10 @@ func (c *Spec) UnmarshalCanotoFrom(r Reader) error {
 			return ErrUnknownField
 		}
 
-
 		minField = field + 1
 	}
 	return nil
 }
-
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -203,7 +189,6 @@ func (c *Spec) ValidCanoto() bool {
 	return true
 }
 
-
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
 //
@@ -227,7 +212,6 @@ func (c *Spec) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
-
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -242,7 +226,6 @@ func (c *Spec) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
-
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -256,7 +239,6 @@ func (c *Spec) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
-
 
 // MarshalCanotoInto writes the struct into a [Writer] and returns the
 // resulting [Writer]. Most users should just use MarshalCanoto.
@@ -286,7 +268,6 @@ func (c *Spec) MarshalCanotoInto(w Writer) Writer {
 	return w
 }
 
-
 const (
 	canoto__FieldType__FieldNumber__tag    = "\x08" // canoto.Tag(1, canoto.Varint)
 	canoto__FieldType__Name__tag           = "\x12" // canoto.Tag(2, canoto.Len)
@@ -305,13 +286,11 @@ const (
 	canoto__FieldType__TypeMessage__tag    = "\x7a" // canoto.Tag(15, canoto.Len)
 )
 
-
 type canotoData_FieldType struct {
 	size uint64
 
 	TypeOneOf uint32
 }
-
 
 // CanotoSpec returns the specification of this canoto message.
 func (*FieldType) CanotoSpec(types ...reflect.Type) *Spec {
@@ -419,12 +398,10 @@ func (*FieldType) CanotoSpec(types ...reflect.Type) *Spec {
 	return s
 }
 
-
 // MakeCanoto creates a new empty value.
 func (*FieldType) MakeCanoto() *FieldType {
 	return new(FieldType)
 }
-
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -435,7 +412,6 @@ func (c *FieldType) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
-
 
 // UnmarshalCanotoFrom populates the struct from a [Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -448,7 +424,6 @@ func (c *FieldType) UnmarshalCanotoFrom(r Reader) error {
 	*c = FieldType{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
-
 	var minField uint32
 	for HasNext(&r) {
 		field, wireType, err := ReadTag(&r)
@@ -458,7 +433,6 @@ func (c *FieldType) UnmarshalCanotoFrom(r Reader) error {
 		if field < minField {
 			return ErrInvalidFieldOrder
 		}
-
 
 		switch field {
 		case 1:
@@ -674,12 +648,10 @@ func (c *FieldType) UnmarshalCanotoFrom(r Reader) error {
 			return ErrUnknownField
 		}
 
-
 		minField = field + 1
 	}
 	return nil
 }
-
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -768,7 +740,6 @@ func (c *FieldType) ValidCanoto() bool {
 	return true
 }
 
-
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
 //
@@ -841,7 +812,6 @@ func (c *FieldType) CalculateCanotoCache() {
 	atomic.StoreUint32(&c.canotoData.TypeOneOf, TypeOneOf)
 }
 
-
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -870,7 +840,6 @@ func (c *FieldType) CachedWhichOneOfType() uint32 {
 	return atomic.LoadUint32(&c.canotoData.TypeOneOf)
 }
 
-
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -884,7 +853,6 @@ func (c *FieldType) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
-
 
 // MarshalCanotoInto writes the struct into a [Writer] and returns the
 // resulting [Writer]. Most users should just use MarshalCanoto.

--- a/canoto.canoto_test.go
+++ b/canoto.canoto_test.go
@@ -2142,13 +2142,9 @@ func (c *OneOf) MarshalCanotoInto(w Writer) Writer {
 	if c == nil {
 		return w
 	}
-	switch c.CachedWhichOneOfA() {
-	case 1:
+	if c.CachedWhichOneOfA() == 1 {
 		Append(&w, canoto__OneOf__A1__tag)
 		AppendInt(&w, c.A1)
-	case 7:
-		Append(&w, canoto__OneOf__A2__tag)
-		AppendInt(&w, c.A2)
 	}
 	switch c.CachedWhichOneOfB() {
 	case 3:
@@ -2165,6 +2161,10 @@ func (c *OneOf) MarshalCanotoInto(w Writer) Writer {
 	if !IsZero(c.D) {
 		Append(&w, canoto__OneOf__D__tag)
 		AppendInt(&w, c.D)
+	}
+	if c.CachedWhichOneOfA() == 7 {
+		Append(&w, canoto__OneOf__A2__tag)
+		AppendInt(&w, c.A2)
 	}
 	return w
 }

--- a/canoto.canoto_test.go
+++ b/canoto.canoto_test.go
@@ -3,7 +3,9 @@
 // 	canoto v0.17.1
 // source: canoto_test.go
 
+
 package canoto
+
 
 import (
 	"io"
@@ -11,12 +13,15 @@ import (
 	"sync/atomic"
 )
 
+
 // Ensure that unused imports do not error
 var (
 	_ atomic.Uint64
 
+
 	_ = io.ErrUnexpectedEOF
 )
+
 
 const (
 	canoto__SpecFuzzer__Int8__tag                       = "\x08"     // canoto.Tag(1, canoto.Varint)
@@ -56,6 +61,7 @@ const (
 	canoto__SpecFuzzer__Recursive__tag                  = "\x9a\x02" // canoto.Tag(35, canoto.Len)
 )
 
+
 type canotoData_SpecFuzzer struct {
 	size               uint64
 	RepeatedInt8Size   uint64
@@ -66,6 +72,7 @@ type canotoData_SpecFuzzer struct {
 	RepeatedUint32Size uint64
 	RepeatedUint64Size uint64
 }
+
 
 // CanotoSpec returns the specification of this canoto message.
 func (*SpecFuzzer) CanotoSpec(types ...reflect.Type) *Spec {
@@ -334,10 +341,12 @@ func (*SpecFuzzer) CanotoSpec(types ...reflect.Type) *Spec {
 	return s
 }
 
+
 // MakeCanoto creates a new empty value.
 func (*SpecFuzzer) MakeCanoto() *SpecFuzzer {
 	return new(SpecFuzzer)
 }
+
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -348,6 +357,7 @@ func (c *SpecFuzzer) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
+
 
 // UnmarshalCanotoFrom populates the struct from a [Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -360,6 +370,7 @@ func (c *SpecFuzzer) UnmarshalCanotoFrom(r Reader) error {
 	*c = SpecFuzzer{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
+
 	var minField uint32
 	for HasNext(&r) {
 		field, wireType, err := ReadTag(&r)
@@ -369,6 +380,7 @@ func (c *SpecFuzzer) UnmarshalCanotoFrom(r Reader) error {
 		if field < minField {
 			return ErrInvalidFieldOrder
 		}
+
 
 		switch field {
 		case 1:
@@ -1185,10 +1197,12 @@ func (c *SpecFuzzer) UnmarshalCanotoFrom(r Reader) error {
 			return ErrUnknownField
 		}
 
+
 		minField = field + 1
 	}
 	return nil
 }
+
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -1234,6 +1248,7 @@ func (c *SpecFuzzer) ValidCanoto() bool {
 	}
 	return true
 }
+
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -1410,6 +1425,7 @@ func (c *SpecFuzzer) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
+
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -1424,6 +1440,7 @@ func (c *SpecFuzzer) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
+
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -1437,6 +1454,7 @@ func (c *SpecFuzzer) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
+
 
 // MarshalCanotoInto writes the struct into a [Writer] and returns the
 // resulting [Writer]. Most users should just use MarshalCanoto.
@@ -1647,13 +1665,16 @@ func (c *SpecFuzzer) MarshalCanotoInto(w Writer) Writer {
 	return w
 }
 
+
 const (
 	canoto__LargestFieldNumber__Uint__tag = "\xf8\xff\xff\xff\x0f" // canoto.Tag(536870911, canoto.Varint)
 )
 
+
 type canotoData_LargestFieldNumber struct {
 	size uint64
 }
+
 
 // CanotoSpec returns the specification of this canoto message.
 func (*LargestFieldNumber[T1]) CanotoSpec(...reflect.Type) *Spec {
@@ -1673,10 +1694,12 @@ func (*LargestFieldNumber[T1]) CanotoSpec(...reflect.Type) *Spec {
 	return s
 }
 
+
 // MakeCanoto creates a new empty value.
 func (*LargestFieldNumber[T1]) MakeCanoto() *LargestFieldNumber[T1] {
 	return new(LargestFieldNumber[T1])
 }
+
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -1687,6 +1710,7 @@ func (c *LargestFieldNumber[T1]) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
+
 
 // UnmarshalCanotoFrom populates the struct from a [Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -1699,6 +1723,7 @@ func (c *LargestFieldNumber[T1]) UnmarshalCanotoFrom(r Reader) error {
 	*c = LargestFieldNumber[T1]{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
+
 	var minField uint32
 	for HasNext(&r) {
 		field, wireType, err := ReadTag(&r)
@@ -1708,6 +1733,7 @@ func (c *LargestFieldNumber[T1]) UnmarshalCanotoFrom(r Reader) error {
 		if field < minField {
 			return ErrInvalidFieldOrder
 		}
+
 
 		switch field {
 		case 536870911:
@@ -1725,10 +1751,12 @@ func (c *LargestFieldNumber[T1]) UnmarshalCanotoFrom(r Reader) error {
 			return ErrUnknownField
 		}
 
+
 		minField = field + 1
 	}
 	return nil
 }
+
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -1743,6 +1771,7 @@ func (c *LargestFieldNumber[T1]) ValidCanoto() bool {
 	}
 	return true
 }
+
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -1759,6 +1788,7 @@ func (c *LargestFieldNumber[T1]) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
+
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -1773,6 +1803,7 @@ func (c *LargestFieldNumber[T1]) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
+
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -1786,6 +1817,7 @@ func (c *LargestFieldNumber[T1]) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
+
 
 // MarshalCanotoInto writes the struct into a [Writer] and returns the
 // resulting [Writer]. Most users should just use MarshalCanoto.
@@ -1807,6 +1839,7 @@ func (c *LargestFieldNumber[T1]) MarshalCanotoInto(w Writer) Writer {
 	return w
 }
 
+
 const (
 	canoto__OneOf__A1__tag = "\x08" // canoto.Tag(1, canoto.Varint)
 	canoto__OneOf__B1__tag = "\x18" // canoto.Tag(3, canoto.Varint)
@@ -1816,12 +1849,14 @@ const (
 	canoto__OneOf__A2__tag = "\x38" // canoto.Tag(7, canoto.Varint)
 )
 
+
 type canotoData_OneOf struct {
 	size uint64
 
 	AOneOf uint32
 	BOneOf uint32
 }
+
 
 // CanotoSpec returns the specification of this canoto message.
 func (*OneOf) CanotoSpec(...reflect.Type) *Spec {
@@ -1871,10 +1906,12 @@ func (*OneOf) CanotoSpec(...reflect.Type) *Spec {
 	return s
 }
 
+
 // MakeCanoto creates a new empty value.
 func (*OneOf) MakeCanoto() *OneOf {
 	return new(OneOf)
 }
+
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -1885,6 +1922,7 @@ func (c *OneOf) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
+
 
 // UnmarshalCanotoFrom populates the struct from a [Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -1897,6 +1935,7 @@ func (c *OneOf) UnmarshalCanotoFrom(r Reader) error {
 	*c = OneOf{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
+
 	var minField uint32
 	for HasNext(&r) {
 		field, wireType, err := ReadTag(&r)
@@ -1906,6 +1945,7 @@ func (c *OneOf) UnmarshalCanotoFrom(r Reader) error {
 		if field < minField {
 			return ErrInvalidFieldOrder
 		}
+
 
 		switch field {
 		case 1:
@@ -1990,10 +2030,12 @@ func (c *OneOf) UnmarshalCanotoFrom(r Reader) error {
 			return ErrUnknownField
 		}
 
+
 		minField = field + 1
 	}
 	return nil
 }
+
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -2035,6 +2077,7 @@ func (c *OneOf) ValidCanoto() bool {
 	return true
 }
 
+
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
 //
@@ -2072,6 +2115,7 @@ func (c *OneOf) CalculateCanotoCache() {
 	atomic.StoreUint32(&c.canotoData.AOneOf, AOneOf)
 	atomic.StoreUint32(&c.canotoData.BOneOf, BOneOf)
 }
+
 
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
@@ -2115,6 +2159,7 @@ func (c *OneOf) CachedWhichOneOfB() uint32 {
 	return atomic.LoadUint32(&c.canotoData.BOneOf)
 }
 
+
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -2129,6 +2174,7 @@ func (c *OneOf) MarshalCanoto() []byte {
 	return w.B
 }
 
+
 // MarshalCanotoInto writes the struct into a [Writer] and returns the
 // resulting [Writer]. Most users should just use MarshalCanoto.
 //
@@ -2142,15 +2188,19 @@ func (c *OneOf) MarshalCanotoInto(w Writer) Writer {
 	if c == nil {
 		return w
 	}
-	if !IsZero(c.A1) {
+	switch c.CachedWhichOneOfA() {
+	case 1:
 		Append(&w, canoto__OneOf__A1__tag)
 		AppendInt(&w, c.A1)
+	case 7:
+		Append(&w, canoto__OneOf__A2__tag)
+		AppendInt(&w, c.A2)
 	}
-	if !IsZero(c.B1) {
+	switch c.CachedWhichOneOfB() {
+	case 3:
 		Append(&w, canoto__OneOf__B1__tag)
 		AppendInt(&w, c.B1)
-	}
-	if !IsZero(c.B2) {
+	case 4:
 		Append(&w, canoto__OneOf__B2__tag)
 		AppendInt(&w, c.B2)
 	}
@@ -2161,10 +2211,6 @@ func (c *OneOf) MarshalCanotoInto(w Writer) Writer {
 	if !IsZero(c.D) {
 		Append(&w, canoto__OneOf__D__tag)
 		AppendInt(&w, c.D)
-	}
-	if !IsZero(c.A2) {
-		Append(&w, canoto__OneOf__A2__tag)
-		AppendInt(&w, c.A2)
 	}
 	return w
 }

--- a/canoto.canoto_test.go
+++ b/canoto.canoto_test.go
@@ -3,9 +3,7 @@
 // 	canoto v0.17.1
 // source: canoto_test.go
 
-
 package canoto
-
 
 import (
 	"io"
@@ -13,15 +11,12 @@ import (
 	"sync/atomic"
 )
 
-
 // Ensure that unused imports do not error
 var (
 	_ atomic.Uint64
 
-
 	_ = io.ErrUnexpectedEOF
 )
-
 
 const (
 	canoto__SpecFuzzer__Int8__tag                       = "\x08"     // canoto.Tag(1, canoto.Varint)
@@ -61,7 +56,6 @@ const (
 	canoto__SpecFuzzer__Recursive__tag                  = "\x9a\x02" // canoto.Tag(35, canoto.Len)
 )
 
-
 type canotoData_SpecFuzzer struct {
 	size               uint64
 	RepeatedInt8Size   uint64
@@ -72,7 +66,6 @@ type canotoData_SpecFuzzer struct {
 	RepeatedUint32Size uint64
 	RepeatedUint64Size uint64
 }
-
 
 // CanotoSpec returns the specification of this canoto message.
 func (*SpecFuzzer) CanotoSpec(types ...reflect.Type) *Spec {
@@ -341,12 +334,10 @@ func (*SpecFuzzer) CanotoSpec(types ...reflect.Type) *Spec {
 	return s
 }
 
-
 // MakeCanoto creates a new empty value.
 func (*SpecFuzzer) MakeCanoto() *SpecFuzzer {
 	return new(SpecFuzzer)
 }
-
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -357,7 +348,6 @@ func (c *SpecFuzzer) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
-
 
 // UnmarshalCanotoFrom populates the struct from a [Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -370,7 +360,6 @@ func (c *SpecFuzzer) UnmarshalCanotoFrom(r Reader) error {
 	*c = SpecFuzzer{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
-
 	var minField uint32
 	for HasNext(&r) {
 		field, wireType, err := ReadTag(&r)
@@ -380,7 +369,6 @@ func (c *SpecFuzzer) UnmarshalCanotoFrom(r Reader) error {
 		if field < minField {
 			return ErrInvalidFieldOrder
 		}
-
 
 		switch field {
 		case 1:
@@ -1197,12 +1185,10 @@ func (c *SpecFuzzer) UnmarshalCanotoFrom(r Reader) error {
 			return ErrUnknownField
 		}
 
-
 		minField = field + 1
 	}
 	return nil
 }
-
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -1248,7 +1234,6 @@ func (c *SpecFuzzer) ValidCanoto() bool {
 	}
 	return true
 }
-
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -1425,7 +1410,6 @@ func (c *SpecFuzzer) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
-
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -1440,7 +1424,6 @@ func (c *SpecFuzzer) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
-
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -1454,7 +1437,6 @@ func (c *SpecFuzzer) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
-
 
 // MarshalCanotoInto writes the struct into a [Writer] and returns the
 // resulting [Writer]. Most users should just use MarshalCanoto.
@@ -1665,16 +1647,13 @@ func (c *SpecFuzzer) MarshalCanotoInto(w Writer) Writer {
 	return w
 }
 
-
 const (
 	canoto__LargestFieldNumber__Uint__tag = "\xf8\xff\xff\xff\x0f" // canoto.Tag(536870911, canoto.Varint)
 )
 
-
 type canotoData_LargestFieldNumber struct {
 	size uint64
 }
-
 
 // CanotoSpec returns the specification of this canoto message.
 func (*LargestFieldNumber[T1]) CanotoSpec(...reflect.Type) *Spec {
@@ -1694,12 +1673,10 @@ func (*LargestFieldNumber[T1]) CanotoSpec(...reflect.Type) *Spec {
 	return s
 }
 
-
 // MakeCanoto creates a new empty value.
 func (*LargestFieldNumber[T1]) MakeCanoto() *LargestFieldNumber[T1] {
 	return new(LargestFieldNumber[T1])
 }
-
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -1710,7 +1687,6 @@ func (c *LargestFieldNumber[T1]) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
-
 
 // UnmarshalCanotoFrom populates the struct from a [Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -1723,7 +1699,6 @@ func (c *LargestFieldNumber[T1]) UnmarshalCanotoFrom(r Reader) error {
 	*c = LargestFieldNumber[T1]{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
-
 	var minField uint32
 	for HasNext(&r) {
 		field, wireType, err := ReadTag(&r)
@@ -1733,7 +1708,6 @@ func (c *LargestFieldNumber[T1]) UnmarshalCanotoFrom(r Reader) error {
 		if field < minField {
 			return ErrInvalidFieldOrder
 		}
-
 
 		switch field {
 		case 536870911:
@@ -1751,12 +1725,10 @@ func (c *LargestFieldNumber[T1]) UnmarshalCanotoFrom(r Reader) error {
 			return ErrUnknownField
 		}
 
-
 		minField = field + 1
 	}
 	return nil
 }
-
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -1771,7 +1743,6 @@ func (c *LargestFieldNumber[T1]) ValidCanoto() bool {
 	}
 	return true
 }
-
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -1788,7 +1759,6 @@ func (c *LargestFieldNumber[T1]) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
-
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -1803,7 +1773,6 @@ func (c *LargestFieldNumber[T1]) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
-
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -1817,7 +1786,6 @@ func (c *LargestFieldNumber[T1]) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
-
 
 // MarshalCanotoInto writes the struct into a [Writer] and returns the
 // resulting [Writer]. Most users should just use MarshalCanoto.
@@ -1839,7 +1807,6 @@ func (c *LargestFieldNumber[T1]) MarshalCanotoInto(w Writer) Writer {
 	return w
 }
 
-
 const (
 	canoto__OneOf__A1__tag = "\x08" // canoto.Tag(1, canoto.Varint)
 	canoto__OneOf__B1__tag = "\x18" // canoto.Tag(3, canoto.Varint)
@@ -1849,14 +1816,12 @@ const (
 	canoto__OneOf__A2__tag = "\x38" // canoto.Tag(7, canoto.Varint)
 )
 
-
 type canotoData_OneOf struct {
 	size uint64
 
 	AOneOf uint32
 	BOneOf uint32
 }
-
 
 // CanotoSpec returns the specification of this canoto message.
 func (*OneOf) CanotoSpec(...reflect.Type) *Spec {
@@ -1906,12 +1871,10 @@ func (*OneOf) CanotoSpec(...reflect.Type) *Spec {
 	return s
 }
 
-
 // MakeCanoto creates a new empty value.
 func (*OneOf) MakeCanoto() *OneOf {
 	return new(OneOf)
 }
-
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -1922,7 +1885,6 @@ func (c *OneOf) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
-
 
 // UnmarshalCanotoFrom populates the struct from a [Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -1935,7 +1897,6 @@ func (c *OneOf) UnmarshalCanotoFrom(r Reader) error {
 	*c = OneOf{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
-
 	var minField uint32
 	for HasNext(&r) {
 		field, wireType, err := ReadTag(&r)
@@ -1945,7 +1906,6 @@ func (c *OneOf) UnmarshalCanotoFrom(r Reader) error {
 		if field < minField {
 			return ErrInvalidFieldOrder
 		}
-
 
 		switch field {
 		case 1:
@@ -2030,12 +1990,10 @@ func (c *OneOf) UnmarshalCanotoFrom(r Reader) error {
 			return ErrUnknownField
 		}
 
-
 		minField = field + 1
 	}
 	return nil
 }
-
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -2077,7 +2035,6 @@ func (c *OneOf) ValidCanoto() bool {
 	return true
 }
 
-
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
 //
@@ -2115,7 +2072,6 @@ func (c *OneOf) CalculateCanotoCache() {
 	atomic.StoreUint32(&c.canotoData.AOneOf, AOneOf)
 	atomic.StoreUint32(&c.canotoData.BOneOf, BOneOf)
 }
-
 
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
@@ -2159,7 +2115,6 @@ func (c *OneOf) CachedWhichOneOfB() uint32 {
 	return atomic.LoadUint32(&c.canotoData.BOneOf)
 }
 
-
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -2173,7 +2128,6 @@ func (c *OneOf) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
-
 
 // MarshalCanotoInto writes the struct into a [Writer] and returns the
 // resulting [Writer]. Most users should just use MarshalCanoto.

--- a/canoto.canoto_test.go
+++ b/canoto.canoto_test.go
@@ -2142,11 +2142,13 @@ func (c *OneOf) MarshalCanotoInto(w Writer) Writer {
 	if c == nil {
 		return w
 	}
-	if c.CachedWhichOneOfA() == 1 {
+	cachedWhichOneOfA := atomic.LoadUint32(&c.canotoData.AOneOf)
+	if cachedWhichOneOfA == 1 {
 		Append(&w, canoto__OneOf__A1__tag)
 		AppendInt(&w, c.A1)
 	}
-	switch c.CachedWhichOneOfB() {
+	cachedWhichOneOfB := atomic.LoadUint32(&c.canotoData.BOneOf)
+	switch cachedWhichOneOfB {
 	case 3:
 		Append(&w, canoto__OneOf__B1__tag)
 		AppendInt(&w, c.B1)
@@ -2162,7 +2164,7 @@ func (c *OneOf) MarshalCanotoInto(w Writer) Writer {
 		Append(&w, canoto__OneOf__D__tag)
 		AppendInt(&w, c.D)
 	}
-	if c.CachedWhichOneOfA() == 7 {
+	if cachedWhichOneOfA == 7 {
 		Append(&w, canoto__OneOf__A2__tag)
 		AppendInt(&w, c.A2)
 	}

--- a/generate/canoto.go
+++ b/generate/canoto.go
@@ -2049,41 +2049,42 @@ func (c *${structName}${generics}) CachedWhichOneOf${oneOf}() uint32 {
 }
 
 func getMarshalTemplates(isOneof bool) messageTemplate {
-	intTemplateBody := `		${selector}Append(&w, canoto__${escapedStructName}__${escapedFieldName}__tag)
+	const (
+		intTemplateBody = `		${selector}Append(&w, canoto__${escapedStructName}__${escapedFieldName}__tag)
 		${selector}Append${suffix}(&w, c.${fieldName})
 `
-	boolTemplateBody := `		${selector}Append(&w, canoto__${escapedStructName}__${escapedFieldName}__tag)
+		boolTemplateBody = `		${selector}Append(&w, canoto__${escapedStructName}__${escapedFieldName}__tag)
 		${selector}AppendBool(&w, true)
 `
-	bytesTemplateBody := `		${selector}Append(&w, canoto__${escapedStructName}__${escapedFieldName}__tag)
+		bytesTemplateBody = `		${selector}Append(&w, canoto__${escapedStructName}__${escapedFieldName}__tag)
 		${selector}AppendBytes(&w, c.${fieldName})
 `
-	fixedBytesTemplateBody := `		${selector}Append(&w, canoto__${escapedStructName}__${escapedFieldName}__tag)
+		fixedBytesTemplateBody = `		${selector}Append(&w, canoto__${escapedStructName}__${escapedFieldName}__tag)
 		${selector}AppendBytes(&w, (&c.${fieldName})[:])
 `
-	valueTemplateBodyOneof := `		fieldSize := ${genericTypeCast}(&c.${fieldName}).CachedCanotoSize()
+		valueTemplateBodyOneof = `		fieldSize := ${genericTypeCast}(&c.${fieldName}).CachedCanotoSize()
 		${selector}Append(&w, canoto__${escapedStructName}__${escapedFieldName}__tag)
 		${selector}AppendUint(&w, fieldSize)
 		w = ${genericTypeCast}(&c.${fieldName}).MarshalCanotoInto(w)
 `
-	pointerTemplateBodyOneof := `		fieldSize := ${genericTypeCast}(c.${fieldName}).CachedCanotoSize()
+		pointerTemplateBodyOneof = `		fieldSize := ${genericTypeCast}(c.${fieldName}).CachedCanotoSize()
 		${selector}Append(&w, canoto__${escapedStructName}__${escapedFieldName}__tag)
 		${selector}AppendUint(&w, fieldSize)
 		w = ${genericTypeCast}(c.${fieldName}).MarshalCanotoInto(w)
 `
-	fieldTemplateBodyOneof := `		fieldSize := c.${fieldName}.CachedCanotoSize()
+		fieldTemplateBodyOneof = `		fieldSize := c.${fieldName}.CachedCanotoSize()
 		${selector}Append(&w, canoto__${escapedStructName}__${escapedFieldName}__tag)
 		${selector}AppendUint(&w, fieldSize)
 		w = c.${fieldName}.MarshalCanotoInto(w)
 `
 
-	valueTemplateRegular := `	if fieldSize := ${genericTypeCast}(&c.${fieldName}).CachedCanotoSize(); fieldSize != 0 {
+		valueTemplateRegular = `	if fieldSize := ${genericTypeCast}(&c.${fieldName}).CachedCanotoSize(); fieldSize != 0 {
 		${selector}Append(&w, canoto__${escapedStructName}__${escapedFieldName}__tag)
 		${selector}AppendUint(&w, fieldSize)
 		w = ${genericTypeCast}(&c.${fieldName}).MarshalCanotoInto(w)
 	}
 `
-	pointerTemplateRegular := `	if c.${fieldName} != nil {
+		pointerTemplateRegular = `	if c.${fieldName} != nil {
 		if fieldSize := ${genericTypeCast}(c.${fieldName}).CachedCanotoSize(); fieldSize != 0 {
 			${selector}Append(&w, canoto__${escapedStructName}__${escapedFieldName}__tag)
 			${selector}AppendUint(&w, fieldSize)
@@ -2091,14 +2092,21 @@ func getMarshalTemplates(isOneof bool) messageTemplate {
 		}
 	}
 `
-	fieldTemplateRegular := `	if fieldSize := c.${fieldName}.CachedCanotoSize(); fieldSize != 0 {
+		fieldTemplateRegular = `	if fieldSize := c.${fieldName}.CachedCanotoSize(); fieldSize != 0 {
 		${selector}Append(&w, canoto__${escapedStructName}__${escapedFieldName}__tag)
 		${selector}AppendUint(&w, fieldSize)
 		w = c.${fieldName}.MarshalCanotoInto(w)
 	}
 `
+	)
 
-	var intTemplate, boolTemplate, bytesTemplate, fixedBytesTemplate, valueTemplate, pointerTemplate, fieldTemplate string
+	var intTemplate,
+		boolTemplate,
+		bytesTemplate,
+		fixedBytesTemplate,
+		valueTemplate,
+		pointerTemplate,
+		fieldTemplate string
 
 	if isOneof {
 		intTemplate = intTemplateBody

--- a/generate/canoto.go
+++ b/generate/canoto.go
@@ -2127,14 +2127,6 @@ func getMarshalTemplates(isOneof bool) messageTemplate {
 		}
 	}
 `
-		fixedRepeatedIntTemplate = `	if !${selector}IsZero(c.${fieldName}) {
-		${selector}Append(&w, canoto__${escapedStructName}__${escapedFieldName}__tag)
-		${selector}AppendUint(&w, ${loadPrefix}c.canotoData.${fieldName}Size${loadSuffix})
-		for _, v := range &c.${fieldName} {
-			${selector}Append${suffix}(&w, v)
-		}
-	}
-`
 		fixedRepeatedFintTemplate = `	if !${selector}IsZero(c.${fieldName}) {
 		const fieldSize = uint64(len(c.${fieldName})) * ${selector}Size${suffix}
 		${selector}Append(&w, canoto__${escapedStructName}__${escapedFieldName}__tag)
@@ -2161,7 +2153,14 @@ func getMarshalTemplates(isOneof bool) messageTemplate {
 		}
 	}
 `,
-			fixedRepeated: fixedRepeatedIntTemplate,
+			fixedRepeated: `	if !${selector}IsZero(c.${fieldName}) {
+		${selector}Append(&w, canoto__${escapedStructName}__${escapedFieldName}__tag)
+		${selector}AppendUint(&w, ${loadPrefix}c.canotoData.${fieldName}Size${loadSuffix})
+		for _, v := range &c.${fieldName} {
+			${selector}Append${suffix}(&w, v)
+		}
+	}
+`,
 		},
 		fints: typeTemplate{
 			single:        intTemplate,

--- a/generate/canoto.go
+++ b/generate/canoto.go
@@ -2110,10 +2110,10 @@ func getMarshalTemplates(isOneof bool) messageTemplate {
 		pointerTemplate = pointerTemplateBodyOneof
 		fieldTemplate = fieldTemplateBodyOneof
 	} else {
-		intTemplate = "	if !${selector}IsZero(c.${fieldName}) {\n" + intTemplateBody + "\t}\n"
-		boolTemplate = "	if !${selector}IsZero(c.${fieldName}) {\n" + boolTemplateBody + "\t}\n"
-		bytesTemplate = "	if len(c.${fieldName}) != 0 {\n" + bytesTemplateBody + "\t}\n"
-		fixedBytesTemplate = "	if !${selector}IsZero(c.${fieldName}) {\n" + fixedBytesTemplateBody + "\t}\n"
+		intTemplate = "\tif !${selector}IsZero(c.${fieldName}) {\n" + intTemplateBody + "\t}\n"
+		boolTemplate = "\tif !${selector}IsZero(c.${fieldName}) {\n" + boolTemplateBody + "\t}\n"
+		bytesTemplate = "\tif len(c.${fieldName}) != 0 {\n" + bytesTemplateBody + "\t}\n"
+		fixedBytesTemplate = "\tif !${selector}IsZero(c.${fieldName}) {\n" + fixedBytesTemplateBody + "\t}\n"
 		valueTemplate = valueTemplateRegular
 		pointerTemplate = pointerTemplateRegular
 		fieldTemplate = fieldTemplateRegular

--- a/generate/canoto.go
+++ b/generate/canoto.go
@@ -2341,12 +2341,14 @@ func getMarshalTemplates(isOneof bool) messageTemplate {
 }
 
 func makeMarshal(m message) string {
-	regularTmpl := getMarshalTemplates(false)
-	oneofTmpl := getMarshalTemplates(true)
+	var (
+		regularTmpl = getMarshalTemplates(false)
+		oneofTmpl   = getMarshalTemplates(true)
 
-	var s strings.Builder
-	processedOneofs := make(map[string]bool)
+		s strings.Builder
 
+		processedOneofs = make(map[string]bool)
+	)
 	for _, f := range m.fields {
 		if f.oneOfName == "" {
 			_ = writeField(&s, f, regularTmpl)

--- a/generate/canoto.go
+++ b/generate/canoto.go
@@ -1,4 +1,3 @@
-// generate/canoto.go
 package generate
 
 import (
@@ -81,9 +80,7 @@ func writeCanoto(
 // 	canoto ${version}
 // source: ${source}
 
-
 package ${package}
-
 
 import (
 	"io"
@@ -91,16 +88,13 @@ import (
 	"sync/atomic"
 ${canotoImport})
 
-
 // Ensure that unused imports do not error
 var (
 	_ atomic.Uint64
 
-
 	_ = io.ErrUnexpectedEOF
 )
 `
-
 	// Only include the import for canoto if this is not an internal file.
 	if internal {
 		canotoImport = ""
@@ -131,14 +125,11 @@ var (
 
 func writeStruct(w io.Writer, m message, canotoSelector string) error {
 	const structTemplate = `
-
 const (
 ${tagConstants})
 
-
 type canotoData_${structName} struct {
 ${sizeCache}${oneOfCache}}
-
 
 // CanotoSpec returns the specification of this canoto message.
 func (*${structName}${generics}) CanotoSpec(${typesDecl}...reflect.Type) *${selector}Spec {
@@ -151,12 +142,10 @@ ${spec}		},
 	return s
 }
 
-
 // MakeCanoto creates a new empty value.
 func (*${structName}${generics}) MakeCanoto() *${structName}${generics} {
 	return new(${structName}${generics})
 }
-
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -167,7 +156,6 @@ func (c *${structName}${generics}) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
-
 
 // UnmarshalCanotoFrom populates the struct from a [${selector}Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -180,7 +168,6 @@ func (c *${structName}${generics}) UnmarshalCanotoFrom(r ${selector}Reader) erro
 	*c = ${structName}${generics}{}
 	${storePrefix}c.canotoData.size${storeJoin}uint64(len(r.B))${storeSuffix}
 
-
 	var minField uint32
 	for ${selector}HasNext(&r) {
 		field, wireType, err := ${selector}ReadTag(&r)
@@ -191,18 +178,15 @@ func (c *${structName}${generics}) UnmarshalCanotoFrom(r ${selector}Reader) erro
 			return ${selector}ErrInvalidFieldOrder
 		}
 
-
 		switch field {
 ${unmarshal}		default:
 			return ${selector}ErrUnknownField
 		}
 
-
 		minField = field + 1
 	}
 	return nil
 }
-
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -218,7 +202,6 @@ func (c *${structName}${generics}) ValidCanoto() bool {
 ${validOneOf}${valid}	return true
 }
 
-
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.${concurrencyWarning}
 func (c *${structName}${generics}) CalculateCanotoCache() {
@@ -226,7 +209,6 @@ func (c *${structName}${generics}) CalculateCanotoCache() {
 		return
 	}
 ${sizeVars}${size}${assignSizeVars}}
-
 
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
@@ -242,7 +224,6 @@ func (c *${structName}${generics}) CachedCanotoSize() uint64 {
 	return ${loadPrefix}c.canotoData.size${loadSuffix}
 }${oneOfCacheAccessors}
 
-
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.${concurrencyWarning}
@@ -254,7 +235,6 @@ func (c *${structName}${generics}) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
-
 
 // MarshalCanotoInto writes the struct into a [${selector}Writer] and returns the
 // resulting [${selector}Writer]. Most users should just use MarshalCanoto.

--- a/internal/canoto.canoto.go
+++ b/internal/canoto.canoto.go
@@ -515,11 +515,13 @@ func (c *OneOf) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 	if c == nil {
 		return w
 	}
-	if c.CachedWhichOneOfA() == 1 {
+	cachedWhichOneOfA := atomic.LoadUint32(&c.canotoData.AOneOf)
+	if cachedWhichOneOfA == 1 {
 		canoto.Append(&w, canoto__OneOf__A1__tag)
 		canoto.AppendInt(&w, c.A1)
 	}
-	switch c.CachedWhichOneOfB() {
+	cachedWhichOneOfB := atomic.LoadUint32(&c.canotoData.BOneOf)
+	switch cachedWhichOneOfB {
 	case 3:
 		canoto.Append(&w, canoto__OneOf__B1__tag)
 		canoto.AppendInt(&w, c.B1)
@@ -535,7 +537,7 @@ func (c *OneOf) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 		canoto.Append(&w, canoto__OneOf__D__tag)
 		canoto.AppendInt(&w, c.D)
 	}
-	if c.CachedWhichOneOfA() == 7 {
+	if cachedWhichOneOfA == 7 {
 		canoto.Append(&w, canoto__OneOf__A2__tag)
 		canoto.AppendInt(&w, c.A2)
 	}
@@ -776,7 +778,8 @@ func (c *Node) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 		canoto.Append(&w, canoto__Node__Value__tag)
 		canoto.AppendInt(&w, c.Value)
 	}
-	if c.CachedWhichOneOfOneOf() == 2 {
+	cachedWhichOneOfOneOf := atomic.LoadUint32(&c.canotoData.OneOfOneOf)
+	if cachedWhichOneOfOneOf == 2 {
 		fieldSize := (c.Next).CachedCanotoSize()
 		canoto.Append(&w, canoto__Node__Next__tag)
 		canoto.AppendUint(&w, fieldSize)

--- a/internal/canoto.canoto.go
+++ b/internal/canoto.canoto.go
@@ -776,8 +776,7 @@ func (c *Node) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 		canoto.Append(&w, canoto__Node__Value__tag)
 		canoto.AppendInt(&w, c.Value)
 	}
-	switch c.CachedWhichOneOfOneOf() {
-	case 2:
+	if c.CachedWhichOneOfOneOf() == 2 {
 		fieldSize := (c.Next).CachedCanotoSize()
 		canoto.Append(&w, canoto__Node__Next__tag)
 		canoto.AppendUint(&w, fieldSize)

--- a/internal/canoto.canoto.go
+++ b/internal/canoto.canoto.go
@@ -3,7 +3,9 @@
 // 	canoto v0.17.1
 // source: canoto.go
 
+
 package examples
+
 
 import (
 	"io"
@@ -13,20 +15,25 @@ import (
 	"github.com/StephenButtolph/canoto"
 )
 
+
 // Ensure that unused imports do not error
 var (
 	_ atomic.Uint64
 
+
 	_ = io.ErrUnexpectedEOF
 )
+
 
 const (
 	canoto__LargestFieldNumber__Uint__tag = "\xf8\xff\xff\xff\x0f" // canoto.Tag(536870911, canoto.Varint)
 )
 
+
 type canotoData_LargestFieldNumber struct {
 	size uint64
 }
+
 
 // CanotoSpec returns the specification of this canoto message.
 func (*LargestFieldNumber[T1]) CanotoSpec(...reflect.Type) *canoto.Spec {
@@ -46,10 +53,12 @@ func (*LargestFieldNumber[T1]) CanotoSpec(...reflect.Type) *canoto.Spec {
 	return s
 }
 
+
 // MakeCanoto creates a new empty value.
 func (*LargestFieldNumber[T1]) MakeCanoto() *LargestFieldNumber[T1] {
 	return new(LargestFieldNumber[T1])
 }
+
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -60,6 +69,7 @@ func (c *LargestFieldNumber[T1]) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
+
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -72,6 +82,7 @@ func (c *LargestFieldNumber[T1]) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = LargestFieldNumber[T1]{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
+
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -81,6 +92,7 @@ func (c *LargestFieldNumber[T1]) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
+
 
 		switch field {
 		case 536870911:
@@ -98,10 +110,12 @@ func (c *LargestFieldNumber[T1]) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
+
 		minField = field + 1
 	}
 	return nil
 }
+
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -116,6 +130,7 @@ func (c *LargestFieldNumber[T1]) ValidCanoto() bool {
 	}
 	return true
 }
+
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -132,6 +147,7 @@ func (c *LargestFieldNumber[T1]) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
+
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -146,6 +162,7 @@ func (c *LargestFieldNumber[T1]) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
+
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -159,6 +176,7 @@ func (c *LargestFieldNumber[T1]) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
+
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.
@@ -180,6 +198,7 @@ func (c *LargestFieldNumber[T1]) MarshalCanotoInto(w canoto.Writer) canoto.Write
 	return w
 }
 
+
 const (
 	canoto__OneOf__A1__tag = "\x08" // canoto.Tag(1, canoto.Varint)
 	canoto__OneOf__B1__tag = "\x18" // canoto.Tag(3, canoto.Varint)
@@ -189,12 +208,14 @@ const (
 	canoto__OneOf__A2__tag = "\x38" // canoto.Tag(7, canoto.Varint)
 )
 
+
 type canotoData_OneOf struct {
 	size uint64
 
 	AOneOf uint32
 	BOneOf uint32
 }
+
 
 // CanotoSpec returns the specification of this canoto message.
 func (*OneOf) CanotoSpec(...reflect.Type) *canoto.Spec {
@@ -244,10 +265,12 @@ func (*OneOf) CanotoSpec(...reflect.Type) *canoto.Spec {
 	return s
 }
 
+
 // MakeCanoto creates a new empty value.
 func (*OneOf) MakeCanoto() *OneOf {
 	return new(OneOf)
 }
+
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -258,6 +281,7 @@ func (c *OneOf) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
+
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -270,6 +294,7 @@ func (c *OneOf) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = OneOf{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
+
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -279,6 +304,7 @@ func (c *OneOf) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
+
 
 		switch field {
 		case 1:
@@ -363,10 +389,12 @@ func (c *OneOf) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
+
 		minField = field + 1
 	}
 	return nil
 }
+
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -408,6 +436,7 @@ func (c *OneOf) ValidCanoto() bool {
 	return true
 }
 
+
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
 //
@@ -445,6 +474,7 @@ func (c *OneOf) CalculateCanotoCache() {
 	atomic.StoreUint32(&c.canotoData.AOneOf, AOneOf)
 	atomic.StoreUint32(&c.canotoData.BOneOf, BOneOf)
 }
+
 
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
@@ -488,6 +518,7 @@ func (c *OneOf) CachedWhichOneOfB() uint32 {
 	return atomic.LoadUint32(&c.canotoData.BOneOf)
 }
 
+
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -502,6 +533,7 @@ func (c *OneOf) MarshalCanoto() []byte {
 	return w.B
 }
 
+
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.
 //
@@ -515,15 +547,19 @@ func (c *OneOf) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 	if c == nil {
 		return w
 	}
-	if !canoto.IsZero(c.A1) {
+	switch c.CachedWhichOneOfA() {
+	case 1:
 		canoto.Append(&w, canoto__OneOf__A1__tag)
 		canoto.AppendInt(&w, c.A1)
+	case 7:
+		canoto.Append(&w, canoto__OneOf__A2__tag)
+		canoto.AppendInt(&w, c.A2)
 	}
-	if !canoto.IsZero(c.B1) {
+	switch c.CachedWhichOneOfB() {
+	case 3:
 		canoto.Append(&w, canoto__OneOf__B1__tag)
 		canoto.AppendInt(&w, c.B1)
-	}
-	if !canoto.IsZero(c.B2) {
+	case 4:
 		canoto.Append(&w, canoto__OneOf__B2__tag)
 		canoto.AppendInt(&w, c.B2)
 	}
@@ -535,23 +571,22 @@ func (c *OneOf) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 		canoto.Append(&w, canoto__OneOf__D__tag)
 		canoto.AppendInt(&w, c.D)
 	}
-	if !canoto.IsZero(c.A2) {
-		canoto.Append(&w, canoto__OneOf__A2__tag)
-		canoto.AppendInt(&w, c.A2)
-	}
 	return w
 }
+
 
 const (
 	canoto__Node__Value__tag = "\x08" // canoto.Tag(1, canoto.Varint)
 	canoto__Node__Next__tag  = "\x12" // canoto.Tag(2, canoto.Len)
 )
 
+
 type canotoData_Node struct {
 	size uint64
 
 	OneOfOneOf uint32
 }
+
 
 // CanotoSpec returns the specification of this canoto message.
 func (*Node) CanotoSpec(types ...reflect.Type) *canoto.Spec {
@@ -581,10 +616,12 @@ func (*Node) CanotoSpec(types ...reflect.Type) *canoto.Spec {
 	return s
 }
 
+
 // MakeCanoto creates a new empty value.
 func (*Node) MakeCanoto() *Node {
 	return new(Node)
 }
+
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -595,6 +632,7 @@ func (c *Node) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
+
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -607,6 +645,7 @@ func (c *Node) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = Node{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
+
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -616,6 +655,7 @@ func (c *Node) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
+
 
 		switch field {
 		case 1:
@@ -661,10 +701,12 @@ func (c *Node) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
+
 		minField = field + 1
 	}
 	return nil
 }
+
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -693,6 +735,7 @@ func (c *Node) ValidCanoto() bool {
 	return true
 }
 
+
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
 //
@@ -716,6 +759,7 @@ func (c *Node) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 	atomic.StoreUint32(&c.canotoData.OneOfOneOf, OneOfOneOf)
 }
+
 
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
@@ -745,6 +789,7 @@ func (c *Node) CachedWhichOneOfOneOf() uint32 {
 	return atomic.LoadUint32(&c.canotoData.OneOfOneOf)
 }
 
+
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -758,6 +803,7 @@ func (c *Node) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
+
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.
@@ -776,23 +822,26 @@ func (c *Node) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 		canoto.Append(&w, canoto__Node__Value__tag)
 		canoto.AppendInt(&w, c.Value)
 	}
-	if c.Next != nil {
-		if fieldSize := (c.Next).CachedCanotoSize(); fieldSize != 0 {
-			canoto.Append(&w, canoto__Node__Next__tag)
-			canoto.AppendUint(&w, fieldSize)
-			w = (c.Next).MarshalCanotoInto(w)
-		}
+	switch c.CachedWhichOneOfOneOf() {
+	case 2:
+		fieldSize := (c.Next).CachedCanotoSize()
+		canoto.Append(&w, canoto__Node__Next__tag)
+		canoto.AppendUint(&w, fieldSize)
+		w = (c.Next).MarshalCanotoInto(w)
 	}
 	return w
 }
+
 
 const (
 	canoto__RecursiveA__Next__tag = "\x0a" // canoto.Tag(1, canoto.Len)
 )
 
+
 type canotoData_RecursiveA struct {
 	size uint64
 }
+
 
 // CanotoSpec returns the specification of this canoto message.
 func (*RecursiveA) CanotoSpec(types ...reflect.Type) *canoto.Spec {
@@ -816,10 +865,12 @@ func (*RecursiveA) CanotoSpec(types ...reflect.Type) *canoto.Spec {
 	return s
 }
 
+
 // MakeCanoto creates a new empty value.
 func (*RecursiveA) MakeCanoto() *RecursiveA {
 	return new(RecursiveA)
 }
+
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -830,6 +881,7 @@ func (c *RecursiveA) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
+
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -842,6 +894,7 @@ func (c *RecursiveA) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = RecursiveA{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
+
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -851,6 +904,7 @@ func (c *RecursiveA) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
+
 
 		switch field {
 		case 1:
@@ -882,10 +936,12 @@ func (c *RecursiveA) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
+
 		minField = field + 1
 	}
 	return nil
 }
+
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -903,6 +959,7 @@ func (c *RecursiveA) ValidCanoto() bool {
 	}
 	return true
 }
+
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -922,6 +979,7 @@ func (c *RecursiveA) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
+
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -936,6 +994,7 @@ func (c *RecursiveA) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
+
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -949,6 +1008,7 @@ func (c *RecursiveA) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
+
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.
@@ -973,13 +1033,16 @@ func (c *RecursiveA) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 	return w
 }
 
+
 const (
 	canoto__RecursiveB__Next__tag = "\x0a" // canoto.Tag(1, canoto.Len)
 )
 
+
 type canotoData_RecursiveB struct {
 	size uint64
 }
+
 
 // CanotoSpec returns the specification of this canoto message.
 func (*RecursiveB) CanotoSpec(types ...reflect.Type) *canoto.Spec {
@@ -1003,10 +1066,12 @@ func (*RecursiveB) CanotoSpec(types ...reflect.Type) *canoto.Spec {
 	return s
 }
 
+
 // MakeCanoto creates a new empty value.
 func (*RecursiveB) MakeCanoto() *RecursiveB {
 	return new(RecursiveB)
 }
+
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -1017,6 +1082,7 @@ func (c *RecursiveB) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
+
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -1029,6 +1095,7 @@ func (c *RecursiveB) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = RecursiveB{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
+
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -1038,6 +1105,7 @@ func (c *RecursiveB) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
+
 
 		switch field {
 		case 1:
@@ -1069,10 +1137,12 @@ func (c *RecursiveB) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
+
 		minField = field + 1
 	}
 	return nil
 }
+
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -1090,6 +1160,7 @@ func (c *RecursiveB) ValidCanoto() bool {
 	}
 	return true
 }
+
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -1109,6 +1180,7 @@ func (c *RecursiveB) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
+
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -1123,6 +1195,7 @@ func (c *RecursiveB) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
+
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -1136,6 +1209,7 @@ func (c *RecursiveB) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
+
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.
@@ -1160,6 +1234,7 @@ func (c *RecursiveB) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 	return w
 }
 
+
 const (
 	canoto__GenericField__Value__tag                = "\x0a" // canoto.Tag(1, canoto.Len)
 	canoto__GenericField__RepeatedValue__tag        = "\x12" // canoto.Tag(2, canoto.Len)
@@ -1172,9 +1247,11 @@ const (
 	canoto__GenericField__FixedRepeatedField__tag   = "\x4a" // canoto.Tag(9, canoto.Len)
 )
 
+
 type canotoData_GenericField struct {
 	size uint64
 }
+
 
 // CanotoSpec returns the specification of this canoto message.
 func (*GenericField[T1, T2, T3]) CanotoSpec(types ...reflect.Type) *canoto.Spec {
@@ -1270,10 +1347,12 @@ func (*GenericField[T1, T2, T3]) CanotoSpec(types ...reflect.Type) *canoto.Spec 
 	return s
 }
 
+
 // MakeCanoto creates a new empty value.
 func (*GenericField[T1, T2, T3]) MakeCanoto() *GenericField[T1, T2, T3] {
 	return new(GenericField[T1, T2, T3])
 }
+
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -1284,6 +1363,7 @@ func (c *GenericField[T1, T2, T3]) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
+
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -1296,6 +1376,7 @@ func (c *GenericField[T1, T2, T3]) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = GenericField[T1, T2, T3]{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
+
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -1305,6 +1386,7 @@ func (c *GenericField[T1, T2, T3]) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
+
 
 		switch field {
 		case 1:
@@ -1714,10 +1796,12 @@ func (c *GenericField[T1, T2, T3]) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
+
 		minField = field + 1
 	}
 	return nil
 }
+
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -1780,6 +1864,7 @@ func (c *GenericField[T1, T2, T3]) ValidCanoto() bool {
 	}
 	return true
 }
+
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -1885,6 +1970,7 @@ func (c *GenericField[T1, T2, T3]) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
+
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -1899,6 +1985,7 @@ func (c *GenericField[T1, T2, T3]) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
+
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -1912,6 +1999,7 @@ func (c *GenericField[T1, T2, T3]) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
+
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.
@@ -2039,6 +2127,7 @@ func (c *GenericField[T1, T2, T3]) MarshalCanotoInto(w canoto.Writer) canoto.Wri
 	return w
 }
 
+
 const (
 	canoto__NestedGenericField__Value__tag                = "\x0a" // canoto.Tag(1, canoto.Len)
 	canoto__NestedGenericField__RepeatedValue__tag        = "\x12" // canoto.Tag(2, canoto.Len)
@@ -2051,9 +2140,11 @@ const (
 	canoto__NestedGenericField__FixedRepeatedField__tag   = "\x4a" // canoto.Tag(9, canoto.Len)
 )
 
+
 type canotoData_NestedGenericField struct {
 	size uint64
 }
+
 
 // CanotoSpec returns the specification of this canoto message.
 func (*NestedGenericField[T1, T2, T3]) CanotoSpec(types ...reflect.Type) *canoto.Spec {
@@ -2149,10 +2240,12 @@ func (*NestedGenericField[T1, T2, T3]) CanotoSpec(types ...reflect.Type) *canoto
 	return s
 }
 
+
 // MakeCanoto creates a new empty value.
 func (*NestedGenericField[T1, T2, T3]) MakeCanoto() *NestedGenericField[T1, T2, T3] {
 	return new(NestedGenericField[T1, T2, T3])
 }
+
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -2163,6 +2256,7 @@ func (c *NestedGenericField[T1, T2, T3]) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
+
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -2175,6 +2269,7 @@ func (c *NestedGenericField[T1, T2, T3]) UnmarshalCanotoFrom(r canoto.Reader) er
 	*c = NestedGenericField[T1, T2, T3]{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
+
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -2184,6 +2279,7 @@ func (c *NestedGenericField[T1, T2, T3]) UnmarshalCanotoFrom(r canoto.Reader) er
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
+
 
 		switch field {
 		case 1:
@@ -2593,10 +2689,12 @@ func (c *NestedGenericField[T1, T2, T3]) UnmarshalCanotoFrom(r canoto.Reader) er
 			return canoto.ErrUnknownField
 		}
 
+
 		minField = field + 1
 	}
 	return nil
 }
+
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -2659,6 +2757,7 @@ func (c *NestedGenericField[T1, T2, T3]) ValidCanoto() bool {
 	}
 	return true
 }
+
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -2764,6 +2863,7 @@ func (c *NestedGenericField[T1, T2, T3]) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
+
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -2778,6 +2878,7 @@ func (c *NestedGenericField[T1, T2, T3]) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
+
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -2791,6 +2892,7 @@ func (c *NestedGenericField[T1, T2, T3]) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
+
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.
@@ -2918,6 +3020,7 @@ func (c *NestedGenericField[T1, T2, T3]) MarshalCanotoInto(w canoto.Writer) cano
 	return w
 }
 
+
 const (
 	canoto__Embedded__OneOf__tag              = "\x0a" // canoto.Tag(1, canoto.Len)
 	canoto__Embedded__LargestFieldNumber__tag = "\x12" // canoto.Tag(2, canoto.Len)
@@ -2925,9 +3028,11 @@ const (
 	canoto__Embedded__Int__tag                = "\x22" // canoto.Tag(4, canoto.Len)
 )
 
+
 type canotoData_Embedded struct {
 	size uint64
 }
+
 
 // CanotoSpec returns the specification of this canoto message.
 func (*Embedded) CanotoSpec(types ...reflect.Type) *canoto.Spec {
@@ -2978,10 +3083,12 @@ func (*Embedded) CanotoSpec(types ...reflect.Type) *canoto.Spec {
 	return s
 }
 
+
 // MakeCanoto creates a new empty value.
 func (*Embedded) MakeCanoto() *Embedded {
 	return new(Embedded)
 }
+
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -2992,6 +3099,7 @@ func (c *Embedded) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
+
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -3004,6 +3112,7 @@ func (c *Embedded) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = Embedded{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
+
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -3013,6 +3122,7 @@ func (c *Embedded) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
+
 
 		switch field {
 		case 1:
@@ -3118,10 +3228,12 @@ func (c *Embedded) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
+
 		minField = field + 1
 	}
 	return nil
 }
+
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -3148,6 +3260,7 @@ func (c *Embedded) ValidCanoto() bool {
 	}
 	return true
 }
+
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -3181,6 +3294,7 @@ func (c *Embedded) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
+
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -3195,6 +3309,7 @@ func (c *Embedded) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
+
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -3208,6 +3323,7 @@ func (c *Embedded) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
+
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.
@@ -3249,13 +3365,16 @@ func (c *Embedded) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 	return w
 }
 
+
 const (
 	canoto__A__B_1_1C__tag = "\x08" // canoto.Tag(1, canoto.Varint)
 )
 
+
 type canotoData_A struct {
 	size uint64
 }
+
 
 // CanotoSpec returns the specification of this canoto message.
 func (*A) CanotoSpec(...reflect.Type) *canoto.Spec {
@@ -3275,10 +3394,12 @@ func (*A) CanotoSpec(...reflect.Type) *canoto.Spec {
 	return s
 }
 
+
 // MakeCanoto creates a new empty value.
 func (*A) MakeCanoto() *A {
 	return new(A)
 }
+
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -3289,6 +3410,7 @@ func (c *A) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
+
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -3301,6 +3423,7 @@ func (c *A) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = A{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
+
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -3310,6 +3433,7 @@ func (c *A) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
+
 
 		switch field {
 		case 1:
@@ -3327,10 +3451,12 @@ func (c *A) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
+
 		minField = field + 1
 	}
 	return nil
 }
+
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -3345,6 +3471,7 @@ func (c *A) ValidCanoto() bool {
 	}
 	return true
 }
+
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -3361,6 +3488,7 @@ func (c *A) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
+
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -3375,6 +3503,7 @@ func (c *A) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
+
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -3388,6 +3517,7 @@ func (c *A) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
+
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.
@@ -3409,13 +3539,16 @@ func (c *A) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 	return w
 }
 
+
 const (
 	canoto__A_1_1B__C__tag = "\x08" // canoto.Tag(1, canoto.Varint)
 )
 
+
 type canotoData_A__B struct {
 	size uint64
 }
+
 
 // CanotoSpec returns the specification of this canoto message.
 func (*A__B) CanotoSpec(...reflect.Type) *canoto.Spec {
@@ -3435,10 +3568,12 @@ func (*A__B) CanotoSpec(...reflect.Type) *canoto.Spec {
 	return s
 }
 
+
 // MakeCanoto creates a new empty value.
 func (*A__B) MakeCanoto() *A__B {
 	return new(A__B)
 }
+
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -3449,6 +3584,7 @@ func (c *A__B) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
+
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -3461,6 +3597,7 @@ func (c *A__B) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = A__B{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
+
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -3470,6 +3607,7 @@ func (c *A__B) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
+
 
 		switch field {
 		case 1:
@@ -3487,10 +3625,12 @@ func (c *A__B) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
+
 		minField = field + 1
 	}
 	return nil
 }
+
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -3505,6 +3645,7 @@ func (c *A__B) ValidCanoto() bool {
 	}
 	return true
 }
+
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -3521,6 +3662,7 @@ func (c *A__B) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
+
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -3535,6 +3677,7 @@ func (c *A__B) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
+
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -3548,6 +3691,7 @@ func (c *A__B) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
+
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.
@@ -3568,6 +3712,7 @@ func (c *A__B) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 	}
 	return w
 }
+
 
 const (
 	canoto__Scalars__Int8__tag                            = "\x08"     // canoto.Tag(1, canoto.Varint)
@@ -3640,6 +3785,7 @@ const (
 	canoto__Scalars__FixedRepeatedField__tag              = "\xa2\x04" // canoto.Tag(68, canoto.Len)
 )
 
+
 type canotoData_Scalars struct {
 	size                    uint64
 	RepeatedInt8Size        uint64
@@ -3660,6 +3806,7 @@ type canotoData_Scalars struct {
 	FixedRepeatedUint64Size uint64
 	ConstRepeatedUint64Size uint64
 }
+
 
 // CanotoSpec returns the specification of this canoto message.
 func (*Scalars) CanotoSpec(types ...reflect.Type) *canoto.Spec {
@@ -4185,10 +4332,12 @@ func (*Scalars) CanotoSpec(types ...reflect.Type) *canoto.Spec {
 	return s
 }
 
+
 // MakeCanoto creates a new empty value.
 func (*Scalars) MakeCanoto() *Scalars {
 	return new(Scalars)
 }
+
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -4199,6 +4348,7 @@ func (c *Scalars) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
+
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -4211,6 +4361,7 @@ func (c *Scalars) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = Scalars{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
+
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -4220,6 +4371,7 @@ func (c *Scalars) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
+
 
 		switch field {
 		case 1:
@@ -6183,10 +6335,12 @@ func (c *Scalars) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
+
 		minField = field + 1
 	}
 	return nil
 }
+
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -6271,6 +6425,7 @@ func (c *Scalars) ValidCanoto() bool {
 	}
 	return true
 }
+
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -6680,6 +6835,7 @@ func (c *Scalars) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
+
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -6694,6 +6850,7 @@ func (c *Scalars) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
+
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -6707,6 +6864,7 @@ func (c *Scalars) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
+
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.
@@ -7192,6 +7350,7 @@ func (c *Scalars) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 	return w
 }
 
+
 const (
 	canoto__SpecUnusedZero__Bool__tag           = "\x08" // canoto.Tag(1, canoto.Varint)
 	canoto__SpecUnusedZero__RepeatedBool__tag   = "\x12" // canoto.Tag(2, canoto.Len)
@@ -7201,9 +7360,11 @@ const (
 	canoto__SpecUnusedZero__RepeatedBytes__tag  = "\x32" // canoto.Tag(6, canoto.Len)
 )
 
+
 type canotoData_SpecUnusedZero struct {
 	size uint64
 }
+
 
 // CanotoSpec returns the specification of this canoto message.
 func (*SpecUnusedZero) CanotoSpec(...reflect.Type) *canoto.Spec {
@@ -7255,10 +7416,12 @@ func (*SpecUnusedZero) CanotoSpec(...reflect.Type) *canoto.Spec {
 	return s
 }
 
+
 // MakeCanoto creates a new empty value.
 func (*SpecUnusedZero) MakeCanoto() *SpecUnusedZero {
 	return new(SpecUnusedZero)
 }
+
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -7269,6 +7432,7 @@ func (c *SpecUnusedZero) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
+
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -7281,6 +7445,7 @@ func (c *SpecUnusedZero) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = SpecUnusedZero{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
+
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -7290,6 +7455,7 @@ func (c *SpecUnusedZero) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
+
 
 		switch field {
 		case 1:
@@ -7437,10 +7603,12 @@ func (c *SpecUnusedZero) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
+
 		minField = field + 1
 	}
 	return nil
 }
+
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -7463,6 +7631,7 @@ func (c *SpecUnusedZero) ValidCanoto() bool {
 	}
 	return true
 }
+
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -7495,6 +7664,7 @@ func (c *SpecUnusedZero) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
+
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -7509,6 +7679,7 @@ func (c *SpecUnusedZero) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
+
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -7522,6 +7693,7 @@ func (c *SpecUnusedZero) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
+
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.

--- a/internal/canoto.canoto.go
+++ b/internal/canoto.canoto.go
@@ -545,6 +545,364 @@ func (c *OneOf) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 }
 
 const (
+	canoto__OneOfNoCopy__A1__tag = "\x08" // canoto.Tag(1, canoto.Varint)
+	canoto__OneOfNoCopy__B1__tag = "\x18" // canoto.Tag(3, canoto.Varint)
+	canoto__OneOfNoCopy__B2__tag = "\x20" // canoto.Tag(4, canoto.Varint)
+	canoto__OneOfNoCopy__C__tag  = "\x28" // canoto.Tag(5, canoto.Varint)
+	canoto__OneOfNoCopy__D__tag  = "\x30" // canoto.Tag(6, canoto.Varint)
+	canoto__OneOfNoCopy__A2__tag = "\x38" // canoto.Tag(7, canoto.Varint)
+)
+
+type canotoData_OneOfNoCopy struct {
+	size atomic.Uint64
+
+	AOneOf atomic.Uint32
+	BOneOf atomic.Uint32
+}
+
+// CanotoSpec returns the specification of this canoto message.
+func (*OneOfNoCopy) CanotoSpec(...reflect.Type) *canoto.Spec {
+	var zero OneOfNoCopy
+	s := &canoto.Spec{
+		Name: "OneOfNoCopy",
+		Fields: []canoto.FieldType{
+			{
+				FieldNumber: 1,
+				Name:        "A1",
+				OneOf:       "A",
+				TypeInt:     canoto.SizeOf(zero.A1),
+			},
+			{
+				FieldNumber: 3,
+				Name:        "B1",
+				OneOf:       "B",
+				TypeInt:     canoto.SizeOf(zero.B1),
+			},
+			{
+				FieldNumber: 4,
+				Name:        "B2",
+				OneOf:       "B",
+				TypeInt:     canoto.SizeOf(zero.B2),
+			},
+			{
+				FieldNumber: 5,
+				Name:        "C",
+				OneOf:       "",
+				TypeInt:     canoto.SizeOf(zero.C),
+			},
+			{
+				FieldNumber: 6,
+				Name:        "D",
+				OneOf:       "",
+				TypeInt:     canoto.SizeOf(zero.D),
+			},
+			{
+				FieldNumber: 7,
+				Name:        "A2",
+				OneOf:       "A",
+				TypeInt:     canoto.SizeOf(zero.A2),
+			},
+		},
+	}
+	s.CalculateCanotoCache()
+	return s
+}
+
+// MakeCanoto creates a new empty value.
+func (*OneOfNoCopy) MakeCanoto() *OneOfNoCopy {
+	return new(OneOfNoCopy)
+}
+
+// UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
+//
+// During parsing, the canoto cache is saved.
+func (c *OneOfNoCopy) UnmarshalCanoto(bytes []byte) error {
+	r := canoto.Reader{
+		B: bytes,
+	}
+	return c.UnmarshalCanotoFrom(r)
+}
+
+// UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
+// should just use UnmarshalCanoto.
+//
+// During parsing, the canoto cache is saved.
+//
+// This function enables configuration of reader options.
+func (c *OneOfNoCopy) UnmarshalCanotoFrom(r canoto.Reader) error {
+	// Zero the struct before unmarshaling.
+	*c = OneOfNoCopy{}
+	c.canotoData.size.Store(uint64(len(r.B)))
+
+	var minField uint32
+	for canoto.HasNext(&r) {
+		field, wireType, err := canoto.ReadTag(&r)
+		if err != nil {
+			return err
+		}
+		if field < minField {
+			return canoto.ErrInvalidFieldOrder
+		}
+
+		switch field {
+		case 1:
+			if wireType != canoto.Varint {
+				return canoto.ErrUnexpectedWireType
+			}
+			if c.canotoData.AOneOf.Swap(1) != 0 {
+				return canoto.ErrDuplicateOneOf
+			}
+
+			if err := canoto.ReadInt(&r, &c.A1); err != nil {
+				return err
+			}
+			if canoto.IsZero(c.A1) {
+				return canoto.ErrZeroValue
+			}
+		case 3:
+			if wireType != canoto.Varint {
+				return canoto.ErrUnexpectedWireType
+			}
+			if c.canotoData.BOneOf.Swap(3) != 0 {
+				return canoto.ErrDuplicateOneOf
+			}
+
+			if err := canoto.ReadInt(&r, &c.B1); err != nil {
+				return err
+			}
+			if canoto.IsZero(c.B1) {
+				return canoto.ErrZeroValue
+			}
+		case 4:
+			if wireType != canoto.Varint {
+				return canoto.ErrUnexpectedWireType
+			}
+			if c.canotoData.BOneOf.Swap(4) != 0 {
+				return canoto.ErrDuplicateOneOf
+			}
+
+			if err := canoto.ReadInt(&r, &c.B2); err != nil {
+				return err
+			}
+			if canoto.IsZero(c.B2) {
+				return canoto.ErrZeroValue
+			}
+		case 5:
+			if wireType != canoto.Varint {
+				return canoto.ErrUnexpectedWireType
+			}
+
+			if err := canoto.ReadInt(&r, &c.C); err != nil {
+				return err
+			}
+			if canoto.IsZero(c.C) {
+				return canoto.ErrZeroValue
+			}
+		case 6:
+			if wireType != canoto.Varint {
+				return canoto.ErrUnexpectedWireType
+			}
+
+			if err := canoto.ReadInt(&r, &c.D); err != nil {
+				return err
+			}
+			if canoto.IsZero(c.D) {
+				return canoto.ErrZeroValue
+			}
+		case 7:
+			if wireType != canoto.Varint {
+				return canoto.ErrUnexpectedWireType
+			}
+			if c.canotoData.AOneOf.Swap(7) != 0 {
+				return canoto.ErrDuplicateOneOf
+			}
+
+			if err := canoto.ReadInt(&r, &c.A2); err != nil {
+				return err
+			}
+			if canoto.IsZero(c.A2) {
+				return canoto.ErrZeroValue
+			}
+		default:
+			return canoto.ErrUnknownField
+		}
+
+		minField = field + 1
+	}
+	return nil
+}
+
+// ValidCanoto validates that the struct can be correctly marshaled into the
+// Canoto format.
+//
+// Specifically, ValidCanoto ensures:
+// 1. All OneOfs are specified at most once.
+// 2. All strings are valid utf-8.
+// 3. All custom fields are ValidCanoto.
+func (c *OneOfNoCopy) ValidCanoto() bool {
+	if c == nil {
+		return true
+	}
+	var AOneOf uint32
+	var BOneOf uint32
+	if !canoto.IsZero(c.A1) {
+		if AOneOf != 0 {
+			return false
+		}
+		AOneOf = 1
+	}
+	if !canoto.IsZero(c.B1) {
+		if BOneOf != 0 {
+			return false
+		}
+		BOneOf = 3
+	}
+	if !canoto.IsZero(c.B2) {
+		if BOneOf != 0 {
+			return false
+		}
+		BOneOf = 4
+	}
+	if !canoto.IsZero(c.A2) {
+		if AOneOf != 0 {
+			return false
+		}
+		AOneOf = 7
+	}
+	return true
+}
+
+// CalculateCanotoCache populates size and OneOf caches based on the current
+// values in the struct.
+func (c *OneOfNoCopy) CalculateCanotoCache() {
+	if c == nil {
+		return
+	}
+	var size uint64
+	var AOneOf uint32
+	var BOneOf uint32
+	if !canoto.IsZero(c.A1) {
+		size += uint64(len(canoto__OneOfNoCopy__A1__tag)) + canoto.SizeInt(c.A1)
+		AOneOf = 1
+	}
+	if !canoto.IsZero(c.B1) {
+		size += uint64(len(canoto__OneOfNoCopy__B1__tag)) + canoto.SizeInt(c.B1)
+		BOneOf = 3
+	}
+	if !canoto.IsZero(c.B2) {
+		size += uint64(len(canoto__OneOfNoCopy__B2__tag)) + canoto.SizeInt(c.B2)
+		BOneOf = 4
+	}
+	if !canoto.IsZero(c.C) {
+		size += uint64(len(canoto__OneOfNoCopy__C__tag)) + canoto.SizeInt(c.C)
+	}
+	if !canoto.IsZero(c.D) {
+		size += uint64(len(canoto__OneOfNoCopy__D__tag)) + canoto.SizeInt(c.D)
+	}
+	if !canoto.IsZero(c.A2) {
+		size += uint64(len(canoto__OneOfNoCopy__A2__tag)) + canoto.SizeInt(c.A2)
+		AOneOf = 7
+	}
+	c.canotoData.size.Store(size)
+	c.canotoData.AOneOf.Store(AOneOf)
+	c.canotoData.BOneOf.Store(BOneOf)
+}
+
+// CachedCanotoSize returns the previously calculated size of the Canoto
+// representation from CalculateCanotoCache.
+//
+// If CalculateCanotoCache has not yet been called, it will return 0.
+//
+// If the struct has been modified since the last call to CalculateCanotoCache,
+// the returned size may be incorrect.
+func (c *OneOfNoCopy) CachedCanotoSize() uint64 {
+	if c == nil {
+		return 0
+	}
+	return c.canotoData.size.Load()
+}
+
+// CachedWhichOneOfA returns the previously calculated field number used
+// to represent A.
+//
+// This field is cached by UnmarshalCanoto, UnmarshalCanotoFrom, and
+// CalculateCanotoCache.
+//
+// If the field has not yet been cached, it will return 0.
+//
+// If the struct has been modified since the field was last cached, the returned
+// field number may be incorrect.
+func (c *OneOfNoCopy) CachedWhichOneOfA() uint32 {
+	return c.canotoData.AOneOf.Load()
+}
+
+// CachedWhichOneOfB returns the previously calculated field number used
+// to represent B.
+//
+// This field is cached by UnmarshalCanoto, UnmarshalCanotoFrom, and
+// CalculateCanotoCache.
+//
+// If the field has not yet been cached, it will return 0.
+//
+// If the struct has been modified since the field was last cached, the returned
+// field number may be incorrect.
+func (c *OneOfNoCopy) CachedWhichOneOfB() uint32 {
+	return c.canotoData.BOneOf.Load()
+}
+
+// MarshalCanoto returns the Canoto representation of this struct.
+//
+// It is assumed that this struct is ValidCanoto.
+func (c *OneOfNoCopy) MarshalCanoto() []byte {
+	c.CalculateCanotoCache()
+	w := canoto.Writer{
+		B: make([]byte, 0, c.CachedCanotoSize()),
+	}
+	w = c.MarshalCanotoInto(w)
+	return w.B
+}
+
+// MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
+// resulting [canoto.Writer]. Most users should just use MarshalCanoto.
+//
+// It is assumed that CalculateCanotoCache has been called since the last
+// modification to this struct.
+//
+// It is assumed that this struct is ValidCanoto.
+func (c *OneOfNoCopy) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
+	if c == nil {
+		return w
+	}
+	cachedWhichOneOfA := c.canotoData.AOneOf.Load()
+	if cachedWhichOneOfA == 1 {
+		canoto.Append(&w, canoto__OneOfNoCopy__A1__tag)
+		canoto.AppendInt(&w, c.A1)
+	}
+	cachedWhichOneOfB := c.canotoData.BOneOf.Load()
+	switch cachedWhichOneOfB {
+	case 3:
+		canoto.Append(&w, canoto__OneOfNoCopy__B1__tag)
+		canoto.AppendInt(&w, c.B1)
+	case 4:
+		canoto.Append(&w, canoto__OneOfNoCopy__B2__tag)
+		canoto.AppendInt(&w, c.B2)
+	}
+	if !canoto.IsZero(c.C) {
+		canoto.Append(&w, canoto__OneOfNoCopy__C__tag)
+		canoto.AppendInt(&w, c.C)
+	}
+	if !canoto.IsZero(c.D) {
+		canoto.Append(&w, canoto__OneOfNoCopy__D__tag)
+		canoto.AppendInt(&w, c.D)
+	}
+	if cachedWhichOneOfA == 7 {
+		canoto.Append(&w, canoto__OneOfNoCopy__A2__tag)
+		canoto.AppendInt(&w, c.A2)
+	}
+	return w
+}
+
+const (
 	canoto__Node__Value__tag = "\x08" // canoto.Tag(1, canoto.Varint)
 	canoto__Node__Next__tag  = "\x12" // canoto.Tag(2, canoto.Len)
 )

--- a/internal/canoto.canoto.go
+++ b/internal/canoto.canoto.go
@@ -515,13 +515,9 @@ func (c *OneOf) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 	if c == nil {
 		return w
 	}
-	switch c.CachedWhichOneOfA() {
-	case 1:
+	if c.CachedWhichOneOfA() == 1 {
 		canoto.Append(&w, canoto__OneOf__A1__tag)
 		canoto.AppendInt(&w, c.A1)
-	case 7:
-		canoto.Append(&w, canoto__OneOf__A2__tag)
-		canoto.AppendInt(&w, c.A2)
 	}
 	switch c.CachedWhichOneOfB() {
 	case 3:
@@ -538,6 +534,10 @@ func (c *OneOf) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 	if !canoto.IsZero(c.D) {
 		canoto.Append(&w, canoto__OneOf__D__tag)
 		canoto.AppendInt(&w, c.D)
+	}
+	if c.CachedWhichOneOfA() == 7 {
+		canoto.Append(&w, canoto__OneOf__A2__tag)
+		canoto.AppendInt(&w, c.A2)
 	}
 	return w
 }

--- a/internal/canoto.canoto.go
+++ b/internal/canoto.canoto.go
@@ -3,9 +3,7 @@
 // 	canoto v0.17.1
 // source: canoto.go
 
-
 package examples
-
 
 import (
 	"io"
@@ -15,25 +13,20 @@ import (
 	"github.com/StephenButtolph/canoto"
 )
 
-
 // Ensure that unused imports do not error
 var (
 	_ atomic.Uint64
 
-
 	_ = io.ErrUnexpectedEOF
 )
-
 
 const (
 	canoto__LargestFieldNumber__Uint__tag = "\xf8\xff\xff\xff\x0f" // canoto.Tag(536870911, canoto.Varint)
 )
 
-
 type canotoData_LargestFieldNumber struct {
 	size uint64
 }
-
 
 // CanotoSpec returns the specification of this canoto message.
 func (*LargestFieldNumber[T1]) CanotoSpec(...reflect.Type) *canoto.Spec {
@@ -53,12 +46,10 @@ func (*LargestFieldNumber[T1]) CanotoSpec(...reflect.Type) *canoto.Spec {
 	return s
 }
 
-
 // MakeCanoto creates a new empty value.
 func (*LargestFieldNumber[T1]) MakeCanoto() *LargestFieldNumber[T1] {
 	return new(LargestFieldNumber[T1])
 }
-
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -69,7 +60,6 @@ func (c *LargestFieldNumber[T1]) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
-
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -82,7 +72,6 @@ func (c *LargestFieldNumber[T1]) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = LargestFieldNumber[T1]{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
-
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -92,7 +81,6 @@ func (c *LargestFieldNumber[T1]) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
-
 
 		switch field {
 		case 536870911:
@@ -110,12 +98,10 @@ func (c *LargestFieldNumber[T1]) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
-
 		minField = field + 1
 	}
 	return nil
 }
-
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -130,7 +116,6 @@ func (c *LargestFieldNumber[T1]) ValidCanoto() bool {
 	}
 	return true
 }
-
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -147,7 +132,6 @@ func (c *LargestFieldNumber[T1]) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
-
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -162,7 +146,6 @@ func (c *LargestFieldNumber[T1]) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
-
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -176,7 +159,6 @@ func (c *LargestFieldNumber[T1]) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
-
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.
@@ -198,7 +180,6 @@ func (c *LargestFieldNumber[T1]) MarshalCanotoInto(w canoto.Writer) canoto.Write
 	return w
 }
 
-
 const (
 	canoto__OneOf__A1__tag = "\x08" // canoto.Tag(1, canoto.Varint)
 	canoto__OneOf__B1__tag = "\x18" // canoto.Tag(3, canoto.Varint)
@@ -208,14 +189,12 @@ const (
 	canoto__OneOf__A2__tag = "\x38" // canoto.Tag(7, canoto.Varint)
 )
 
-
 type canotoData_OneOf struct {
 	size uint64
 
 	AOneOf uint32
 	BOneOf uint32
 }
-
 
 // CanotoSpec returns the specification of this canoto message.
 func (*OneOf) CanotoSpec(...reflect.Type) *canoto.Spec {
@@ -265,12 +244,10 @@ func (*OneOf) CanotoSpec(...reflect.Type) *canoto.Spec {
 	return s
 }
 
-
 // MakeCanoto creates a new empty value.
 func (*OneOf) MakeCanoto() *OneOf {
 	return new(OneOf)
 }
-
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -281,7 +258,6 @@ func (c *OneOf) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
-
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -294,7 +270,6 @@ func (c *OneOf) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = OneOf{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
-
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -304,7 +279,6 @@ func (c *OneOf) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
-
 
 		switch field {
 		case 1:
@@ -389,12 +363,10 @@ func (c *OneOf) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
-
 		minField = field + 1
 	}
 	return nil
 }
-
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -436,7 +408,6 @@ func (c *OneOf) ValidCanoto() bool {
 	return true
 }
 
-
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
 //
@@ -474,7 +445,6 @@ func (c *OneOf) CalculateCanotoCache() {
 	atomic.StoreUint32(&c.canotoData.AOneOf, AOneOf)
 	atomic.StoreUint32(&c.canotoData.BOneOf, BOneOf)
 }
-
 
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
@@ -518,7 +488,6 @@ func (c *OneOf) CachedWhichOneOfB() uint32 {
 	return atomic.LoadUint32(&c.canotoData.BOneOf)
 }
 
-
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -532,7 +501,6 @@ func (c *OneOf) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
-
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.
@@ -574,19 +542,16 @@ func (c *OneOf) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 	return w
 }
 
-
 const (
 	canoto__Node__Value__tag = "\x08" // canoto.Tag(1, canoto.Varint)
 	canoto__Node__Next__tag  = "\x12" // canoto.Tag(2, canoto.Len)
 )
-
 
 type canotoData_Node struct {
 	size uint64
 
 	OneOfOneOf uint32
 }
-
 
 // CanotoSpec returns the specification of this canoto message.
 func (*Node) CanotoSpec(types ...reflect.Type) *canoto.Spec {
@@ -616,12 +581,10 @@ func (*Node) CanotoSpec(types ...reflect.Type) *canoto.Spec {
 	return s
 }
 
-
 // MakeCanoto creates a new empty value.
 func (*Node) MakeCanoto() *Node {
 	return new(Node)
 }
-
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -632,7 +595,6 @@ func (c *Node) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
-
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -645,7 +607,6 @@ func (c *Node) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = Node{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
-
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -655,7 +616,6 @@ func (c *Node) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
-
 
 		switch field {
 		case 1:
@@ -701,12 +661,10 @@ func (c *Node) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
-
 		minField = field + 1
 	}
 	return nil
 }
-
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -735,7 +693,6 @@ func (c *Node) ValidCanoto() bool {
 	return true
 }
 
-
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
 //
@@ -759,7 +716,6 @@ func (c *Node) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 	atomic.StoreUint32(&c.canotoData.OneOfOneOf, OneOfOneOf)
 }
-
 
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
@@ -789,7 +745,6 @@ func (c *Node) CachedWhichOneOfOneOf() uint32 {
 	return atomic.LoadUint32(&c.canotoData.OneOfOneOf)
 }
 
-
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -803,7 +758,6 @@ func (c *Node) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
-
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.
@@ -832,16 +786,13 @@ func (c *Node) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 	return w
 }
 
-
 const (
 	canoto__RecursiveA__Next__tag = "\x0a" // canoto.Tag(1, canoto.Len)
 )
 
-
 type canotoData_RecursiveA struct {
 	size uint64
 }
-
 
 // CanotoSpec returns the specification of this canoto message.
 func (*RecursiveA) CanotoSpec(types ...reflect.Type) *canoto.Spec {
@@ -865,12 +816,10 @@ func (*RecursiveA) CanotoSpec(types ...reflect.Type) *canoto.Spec {
 	return s
 }
 
-
 // MakeCanoto creates a new empty value.
 func (*RecursiveA) MakeCanoto() *RecursiveA {
 	return new(RecursiveA)
 }
-
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -881,7 +830,6 @@ func (c *RecursiveA) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
-
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -894,7 +842,6 @@ func (c *RecursiveA) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = RecursiveA{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
-
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -904,7 +851,6 @@ func (c *RecursiveA) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
-
 
 		switch field {
 		case 1:
@@ -936,12 +882,10 @@ func (c *RecursiveA) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
-
 		minField = field + 1
 	}
 	return nil
 }
-
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -959,7 +903,6 @@ func (c *RecursiveA) ValidCanoto() bool {
 	}
 	return true
 }
-
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -979,7 +922,6 @@ func (c *RecursiveA) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
-
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -994,7 +936,6 @@ func (c *RecursiveA) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
-
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -1008,7 +949,6 @@ func (c *RecursiveA) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
-
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.
@@ -1033,16 +973,13 @@ func (c *RecursiveA) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 	return w
 }
 
-
 const (
 	canoto__RecursiveB__Next__tag = "\x0a" // canoto.Tag(1, canoto.Len)
 )
 
-
 type canotoData_RecursiveB struct {
 	size uint64
 }
-
 
 // CanotoSpec returns the specification of this canoto message.
 func (*RecursiveB) CanotoSpec(types ...reflect.Type) *canoto.Spec {
@@ -1066,12 +1003,10 @@ func (*RecursiveB) CanotoSpec(types ...reflect.Type) *canoto.Spec {
 	return s
 }
 
-
 // MakeCanoto creates a new empty value.
 func (*RecursiveB) MakeCanoto() *RecursiveB {
 	return new(RecursiveB)
 }
-
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -1082,7 +1017,6 @@ func (c *RecursiveB) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
-
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -1095,7 +1029,6 @@ func (c *RecursiveB) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = RecursiveB{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
-
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -1105,7 +1038,6 @@ func (c *RecursiveB) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
-
 
 		switch field {
 		case 1:
@@ -1137,12 +1069,10 @@ func (c *RecursiveB) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
-
 		minField = field + 1
 	}
 	return nil
 }
-
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -1160,7 +1090,6 @@ func (c *RecursiveB) ValidCanoto() bool {
 	}
 	return true
 }
-
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -1180,7 +1109,6 @@ func (c *RecursiveB) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
-
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -1195,7 +1123,6 @@ func (c *RecursiveB) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
-
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -1209,7 +1136,6 @@ func (c *RecursiveB) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
-
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.
@@ -1234,7 +1160,6 @@ func (c *RecursiveB) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 	return w
 }
 
-
 const (
 	canoto__GenericField__Value__tag                = "\x0a" // canoto.Tag(1, canoto.Len)
 	canoto__GenericField__RepeatedValue__tag        = "\x12" // canoto.Tag(2, canoto.Len)
@@ -1247,11 +1172,9 @@ const (
 	canoto__GenericField__FixedRepeatedField__tag   = "\x4a" // canoto.Tag(9, canoto.Len)
 )
 
-
 type canotoData_GenericField struct {
 	size uint64
 }
-
 
 // CanotoSpec returns the specification of this canoto message.
 func (*GenericField[T1, T2, T3]) CanotoSpec(types ...reflect.Type) *canoto.Spec {
@@ -1347,12 +1270,10 @@ func (*GenericField[T1, T2, T3]) CanotoSpec(types ...reflect.Type) *canoto.Spec 
 	return s
 }
 
-
 // MakeCanoto creates a new empty value.
 func (*GenericField[T1, T2, T3]) MakeCanoto() *GenericField[T1, T2, T3] {
 	return new(GenericField[T1, T2, T3])
 }
-
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -1363,7 +1284,6 @@ func (c *GenericField[T1, T2, T3]) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
-
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -1376,7 +1296,6 @@ func (c *GenericField[T1, T2, T3]) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = GenericField[T1, T2, T3]{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
-
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -1386,7 +1305,6 @@ func (c *GenericField[T1, T2, T3]) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
-
 
 		switch field {
 		case 1:
@@ -1796,12 +1714,10 @@ func (c *GenericField[T1, T2, T3]) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
-
 		minField = field + 1
 	}
 	return nil
 }
-
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -1864,7 +1780,6 @@ func (c *GenericField[T1, T2, T3]) ValidCanoto() bool {
 	}
 	return true
 }
-
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -1970,7 +1885,6 @@ func (c *GenericField[T1, T2, T3]) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
-
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -1985,7 +1899,6 @@ func (c *GenericField[T1, T2, T3]) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
-
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -1999,7 +1912,6 @@ func (c *GenericField[T1, T2, T3]) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
-
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.
@@ -2127,7 +2039,6 @@ func (c *GenericField[T1, T2, T3]) MarshalCanotoInto(w canoto.Writer) canoto.Wri
 	return w
 }
 
-
 const (
 	canoto__NestedGenericField__Value__tag                = "\x0a" // canoto.Tag(1, canoto.Len)
 	canoto__NestedGenericField__RepeatedValue__tag        = "\x12" // canoto.Tag(2, canoto.Len)
@@ -2140,11 +2051,9 @@ const (
 	canoto__NestedGenericField__FixedRepeatedField__tag   = "\x4a" // canoto.Tag(9, canoto.Len)
 )
 
-
 type canotoData_NestedGenericField struct {
 	size uint64
 }
-
 
 // CanotoSpec returns the specification of this canoto message.
 func (*NestedGenericField[T1, T2, T3]) CanotoSpec(types ...reflect.Type) *canoto.Spec {
@@ -2240,12 +2149,10 @@ func (*NestedGenericField[T1, T2, T3]) CanotoSpec(types ...reflect.Type) *canoto
 	return s
 }
 
-
 // MakeCanoto creates a new empty value.
 func (*NestedGenericField[T1, T2, T3]) MakeCanoto() *NestedGenericField[T1, T2, T3] {
 	return new(NestedGenericField[T1, T2, T3])
 }
-
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -2256,7 +2163,6 @@ func (c *NestedGenericField[T1, T2, T3]) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
-
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -2269,7 +2175,6 @@ func (c *NestedGenericField[T1, T2, T3]) UnmarshalCanotoFrom(r canoto.Reader) er
 	*c = NestedGenericField[T1, T2, T3]{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
-
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -2279,7 +2184,6 @@ func (c *NestedGenericField[T1, T2, T3]) UnmarshalCanotoFrom(r canoto.Reader) er
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
-
 
 		switch field {
 		case 1:
@@ -2689,12 +2593,10 @@ func (c *NestedGenericField[T1, T2, T3]) UnmarshalCanotoFrom(r canoto.Reader) er
 			return canoto.ErrUnknownField
 		}
 
-
 		minField = field + 1
 	}
 	return nil
 }
-
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -2757,7 +2659,6 @@ func (c *NestedGenericField[T1, T2, T3]) ValidCanoto() bool {
 	}
 	return true
 }
-
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -2863,7 +2764,6 @@ func (c *NestedGenericField[T1, T2, T3]) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
-
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -2878,7 +2778,6 @@ func (c *NestedGenericField[T1, T2, T3]) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
-
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -2892,7 +2791,6 @@ func (c *NestedGenericField[T1, T2, T3]) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
-
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.
@@ -3020,7 +2918,6 @@ func (c *NestedGenericField[T1, T2, T3]) MarshalCanotoInto(w canoto.Writer) cano
 	return w
 }
 
-
 const (
 	canoto__Embedded__OneOf__tag              = "\x0a" // canoto.Tag(1, canoto.Len)
 	canoto__Embedded__LargestFieldNumber__tag = "\x12" // canoto.Tag(2, canoto.Len)
@@ -3028,11 +2925,9 @@ const (
 	canoto__Embedded__Int__tag                = "\x22" // canoto.Tag(4, canoto.Len)
 )
 
-
 type canotoData_Embedded struct {
 	size uint64
 }
-
 
 // CanotoSpec returns the specification of this canoto message.
 func (*Embedded) CanotoSpec(types ...reflect.Type) *canoto.Spec {
@@ -3083,12 +2978,10 @@ func (*Embedded) CanotoSpec(types ...reflect.Type) *canoto.Spec {
 	return s
 }
 
-
 // MakeCanoto creates a new empty value.
 func (*Embedded) MakeCanoto() *Embedded {
 	return new(Embedded)
 }
-
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -3099,7 +2992,6 @@ func (c *Embedded) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
-
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -3112,7 +3004,6 @@ func (c *Embedded) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = Embedded{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
-
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -3122,7 +3013,6 @@ func (c *Embedded) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
-
 
 		switch field {
 		case 1:
@@ -3228,12 +3118,10 @@ func (c *Embedded) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
-
 		minField = field + 1
 	}
 	return nil
 }
-
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -3260,7 +3148,6 @@ func (c *Embedded) ValidCanoto() bool {
 	}
 	return true
 }
-
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -3294,7 +3181,6 @@ func (c *Embedded) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
-
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -3309,7 +3195,6 @@ func (c *Embedded) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
-
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -3323,7 +3208,6 @@ func (c *Embedded) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
-
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.
@@ -3365,16 +3249,13 @@ func (c *Embedded) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 	return w
 }
 
-
 const (
 	canoto__A__B_1_1C__tag = "\x08" // canoto.Tag(1, canoto.Varint)
 )
 
-
 type canotoData_A struct {
 	size uint64
 }
-
 
 // CanotoSpec returns the specification of this canoto message.
 func (*A) CanotoSpec(...reflect.Type) *canoto.Spec {
@@ -3394,12 +3275,10 @@ func (*A) CanotoSpec(...reflect.Type) *canoto.Spec {
 	return s
 }
 
-
 // MakeCanoto creates a new empty value.
 func (*A) MakeCanoto() *A {
 	return new(A)
 }
-
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -3410,7 +3289,6 @@ func (c *A) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
-
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -3423,7 +3301,6 @@ func (c *A) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = A{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
-
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -3433,7 +3310,6 @@ func (c *A) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
-
 
 		switch field {
 		case 1:
@@ -3451,12 +3327,10 @@ func (c *A) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
-
 		minField = field + 1
 	}
 	return nil
 }
-
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -3471,7 +3345,6 @@ func (c *A) ValidCanoto() bool {
 	}
 	return true
 }
-
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -3488,7 +3361,6 @@ func (c *A) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
-
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -3503,7 +3375,6 @@ func (c *A) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
-
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -3517,7 +3388,6 @@ func (c *A) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
-
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.
@@ -3539,16 +3409,13 @@ func (c *A) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 	return w
 }
 
-
 const (
 	canoto__A_1_1B__C__tag = "\x08" // canoto.Tag(1, canoto.Varint)
 )
 
-
 type canotoData_A__B struct {
 	size uint64
 }
-
 
 // CanotoSpec returns the specification of this canoto message.
 func (*A__B) CanotoSpec(...reflect.Type) *canoto.Spec {
@@ -3568,12 +3435,10 @@ func (*A__B) CanotoSpec(...reflect.Type) *canoto.Spec {
 	return s
 }
 
-
 // MakeCanoto creates a new empty value.
 func (*A__B) MakeCanoto() *A__B {
 	return new(A__B)
 }
-
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -3584,7 +3449,6 @@ func (c *A__B) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
-
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -3597,7 +3461,6 @@ func (c *A__B) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = A__B{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
-
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -3607,7 +3470,6 @@ func (c *A__B) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
-
 
 		switch field {
 		case 1:
@@ -3625,12 +3487,10 @@ func (c *A__B) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
-
 		minField = field + 1
 	}
 	return nil
 }
-
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -3645,7 +3505,6 @@ func (c *A__B) ValidCanoto() bool {
 	}
 	return true
 }
-
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -3662,7 +3521,6 @@ func (c *A__B) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
-
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -3677,7 +3535,6 @@ func (c *A__B) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
-
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -3691,7 +3548,6 @@ func (c *A__B) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
-
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.
@@ -3712,7 +3568,6 @@ func (c *A__B) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 	}
 	return w
 }
-
 
 const (
 	canoto__Scalars__Int8__tag                            = "\x08"     // canoto.Tag(1, canoto.Varint)
@@ -3785,7 +3640,6 @@ const (
 	canoto__Scalars__FixedRepeatedField__tag              = "\xa2\x04" // canoto.Tag(68, canoto.Len)
 )
 
-
 type canotoData_Scalars struct {
 	size                    uint64
 	RepeatedInt8Size        uint64
@@ -3806,7 +3660,6 @@ type canotoData_Scalars struct {
 	FixedRepeatedUint64Size uint64
 	ConstRepeatedUint64Size uint64
 }
-
 
 // CanotoSpec returns the specification of this canoto message.
 func (*Scalars) CanotoSpec(types ...reflect.Type) *canoto.Spec {
@@ -4332,12 +4185,10 @@ func (*Scalars) CanotoSpec(types ...reflect.Type) *canoto.Spec {
 	return s
 }
 
-
 // MakeCanoto creates a new empty value.
 func (*Scalars) MakeCanoto() *Scalars {
 	return new(Scalars)
 }
-
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -4348,7 +4199,6 @@ func (c *Scalars) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
-
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -4361,7 +4211,6 @@ func (c *Scalars) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = Scalars{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
-
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -4371,7 +4220,6 @@ func (c *Scalars) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
-
 
 		switch field {
 		case 1:
@@ -6335,12 +6183,10 @@ func (c *Scalars) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
-
 		minField = field + 1
 	}
 	return nil
 }
-
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -6425,7 +6271,6 @@ func (c *Scalars) ValidCanoto() bool {
 	}
 	return true
 }
-
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -6835,7 +6680,6 @@ func (c *Scalars) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
-
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -6850,7 +6694,6 @@ func (c *Scalars) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
-
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -6864,7 +6707,6 @@ func (c *Scalars) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
-
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.
@@ -7350,7 +7192,6 @@ func (c *Scalars) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 	return w
 }
 
-
 const (
 	canoto__SpecUnusedZero__Bool__tag           = "\x08" // canoto.Tag(1, canoto.Varint)
 	canoto__SpecUnusedZero__RepeatedBool__tag   = "\x12" // canoto.Tag(2, canoto.Len)
@@ -7360,11 +7201,9 @@ const (
 	canoto__SpecUnusedZero__RepeatedBytes__tag  = "\x32" // canoto.Tag(6, canoto.Len)
 )
 
-
 type canotoData_SpecUnusedZero struct {
 	size uint64
 }
-
 
 // CanotoSpec returns the specification of this canoto message.
 func (*SpecUnusedZero) CanotoSpec(...reflect.Type) *canoto.Spec {
@@ -7416,12 +7255,10 @@ func (*SpecUnusedZero) CanotoSpec(...reflect.Type) *canoto.Spec {
 	return s
 }
 
-
 // MakeCanoto creates a new empty value.
 func (*SpecUnusedZero) MakeCanoto() *SpecUnusedZero {
 	return new(SpecUnusedZero)
 }
-
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -7432,7 +7269,6 @@ func (c *SpecUnusedZero) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
-
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -7445,7 +7281,6 @@ func (c *SpecUnusedZero) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = SpecUnusedZero{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
-
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -7455,7 +7290,6 @@ func (c *SpecUnusedZero) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
-
 
 		switch field {
 		case 1:
@@ -7603,12 +7437,10 @@ func (c *SpecUnusedZero) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
-
 		minField = field + 1
 	}
 	return nil
 }
-
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -7631,7 +7463,6 @@ func (c *SpecUnusedZero) ValidCanoto() bool {
 	}
 	return true
 }
-
 
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
@@ -7664,7 +7495,6 @@ func (c *SpecUnusedZero) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
-
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -7679,7 +7509,6 @@ func (c *SpecUnusedZero) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
-
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -7693,7 +7522,6 @@ func (c *SpecUnusedZero) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
-
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.

--- a/internal/canoto.go
+++ b/internal/canoto.go
@@ -49,6 +49,17 @@ type OneOf struct {
 	canotoData canotoData_OneOf
 }
 
+type OneOfNoCopy struct {
+	A1 int32 `canoto:"int,1,A"`
+	A2 int64 `canoto:"int,7,A"`
+	B1 int32 `canoto:"int,3,B"`
+	B2 int64 `canoto:"int,4,B"`
+	C  int32 `canoto:"int,5"`
+	D  int64 `canoto:"int,6"`
+
+	canotoData canotoData_OneOfNoCopy `canoto:"nocopy"`
+}
+
 type Node struct {
 	Value int32 `canoto:"int,1"`
 	Next  *Node `canoto:"pointer,2,OneOf"`

--- a/internal/canoto.proto
+++ b/internal/canoto.proto
@@ -24,6 +24,19 @@ message OneOf {
   sint64 D = 6;
 }
 
+message OneOfNoCopy {
+  oneof A {
+    sint32 A1 = 1;
+    sint64 A2 = 7;
+  }
+  oneof B {
+    sint32 B1 = 3;
+    sint64 B2 = 4;
+  }
+  sint32 C = 5;
+  sint64 D = 6;
+}
+
 message Node {
   oneof OneOf {
     Node Next = 2;

--- a/internal/canoto/canoto.canoto.go
+++ b/internal/canoto/canoto.canoto.go
@@ -887,7 +887,8 @@ func (c *FieldType) MarshalCanotoInto(w Writer) Writer {
 		Append(&w, canoto__FieldType__OneOf__tag)
 		AppendBytes(&w, c.OneOf)
 	}
-	switch c.CachedWhichOneOfType() {
+	cachedWhichOneOfType := atomic.LoadUint32(&c.canotoData.TypeOneOf)
+	switch cachedWhichOneOfType {
 	case 6:
 		Append(&w, canoto__FieldType__TypeInt__tag)
 		AppendUint(&w, c.TypeInt)

--- a/internal/canoto/canoto.canoto.go
+++ b/internal/canoto/canoto.canoto.go
@@ -3,7 +3,9 @@
 // 	canoto v0.17.1
 // source: canoto.go
 
+
 package canoto
+
 
 import (
 	"io"
@@ -11,21 +13,26 @@ import (
 	"sync/atomic"
 )
 
+
 // Ensure that unused imports do not error
 var (
 	_ atomic.Uint64
 
+
 	_ = io.ErrUnexpectedEOF
 )
+
 
 const (
 	canoto__Spec__Name__tag   = "\x0a" // canoto.Tag(1, canoto.Len)
 	canoto__Spec__Fields__tag = "\x12" // canoto.Tag(2, canoto.Len)
 )
 
+
 type canotoData_Spec struct {
 	size uint64
 }
+
 
 // CanotoSpec returns the specification of this canoto message.
 func (*Spec) CanotoSpec(types ...reflect.Type) *Spec {
@@ -55,10 +62,12 @@ func (*Spec) CanotoSpec(types ...reflect.Type) *Spec {
 	return s
 }
 
+
 // MakeCanoto creates a new empty value.
 func (*Spec) MakeCanoto() *Spec {
 	return new(Spec)
 }
+
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -69,6 +78,7 @@ func (c *Spec) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
+
 
 // UnmarshalCanotoFrom populates the struct from a [Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -81,6 +91,7 @@ func (c *Spec) UnmarshalCanotoFrom(r Reader) error {
 	*c = Spec{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
+
 	var minField uint32
 	for HasNext(&r) {
 		field, wireType, err := ReadTag(&r)
@@ -90,6 +101,7 @@ func (c *Spec) UnmarshalCanotoFrom(r Reader) error {
 		if field < minField {
 			return ErrInvalidFieldOrder
 		}
+
 
 		switch field {
 		case 1:
@@ -159,10 +171,12 @@ func (c *Spec) UnmarshalCanotoFrom(r Reader) error {
 			return ErrUnknownField
 		}
 
+
 		minField = field + 1
 	}
 	return nil
 }
+
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -189,6 +203,7 @@ func (c *Spec) ValidCanoto() bool {
 	return true
 }
 
+
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
 //
@@ -212,6 +227,7 @@ func (c *Spec) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
+
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -226,6 +242,7 @@ func (c *Spec) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
+
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -239,6 +256,7 @@ func (c *Spec) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
+
 
 // MarshalCanotoInto writes the struct into a [Writer] and returns the
 // resulting [Writer]. Most users should just use MarshalCanoto.
@@ -268,6 +286,7 @@ func (c *Spec) MarshalCanotoInto(w Writer) Writer {
 	return w
 }
 
+
 const (
 	canoto__FieldType__FieldNumber__tag    = "\x08" // canoto.Tag(1, canoto.Varint)
 	canoto__FieldType__Name__tag           = "\x12" // canoto.Tag(2, canoto.Len)
@@ -286,11 +305,13 @@ const (
 	canoto__FieldType__TypeMessage__tag    = "\x7a" // canoto.Tag(15, canoto.Len)
 )
 
+
 type canotoData_FieldType struct {
 	size uint64
 
 	TypeOneOf uint32
 }
+
 
 // CanotoSpec returns the specification of this canoto message.
 func (*FieldType) CanotoSpec(types ...reflect.Type) *Spec {
@@ -398,10 +419,12 @@ func (*FieldType) CanotoSpec(types ...reflect.Type) *Spec {
 	return s
 }
 
+
 // MakeCanoto creates a new empty value.
 func (*FieldType) MakeCanoto() *FieldType {
 	return new(FieldType)
 }
+
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -412,6 +435,7 @@ func (c *FieldType) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
+
 
 // UnmarshalCanotoFrom populates the struct from a [Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -424,6 +448,7 @@ func (c *FieldType) UnmarshalCanotoFrom(r Reader) error {
 	*c = FieldType{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
+
 	var minField uint32
 	for HasNext(&r) {
 		field, wireType, err := ReadTag(&r)
@@ -433,6 +458,7 @@ func (c *FieldType) UnmarshalCanotoFrom(r Reader) error {
 		if field < minField {
 			return ErrInvalidFieldOrder
 		}
+
 
 		switch field {
 		case 1:
@@ -648,10 +674,12 @@ func (c *FieldType) UnmarshalCanotoFrom(r Reader) error {
 			return ErrUnknownField
 		}
 
+
 		minField = field + 1
 	}
 	return nil
 }
+
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -740,6 +768,7 @@ func (c *FieldType) ValidCanoto() bool {
 	return true
 }
 
+
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
 //
@@ -812,6 +841,7 @@ func (c *FieldType) CalculateCanotoCache() {
 	atomic.StoreUint32(&c.canotoData.TypeOneOf, TypeOneOf)
 }
 
+
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -840,6 +870,7 @@ func (c *FieldType) CachedWhichOneOfType() uint32 {
 	return atomic.LoadUint32(&c.canotoData.TypeOneOf)
 }
 
+
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -853,6 +884,7 @@ func (c *FieldType) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
+
 
 // MarshalCanotoInto writes the struct into a [Writer] and returns the
 // resulting [Writer]. Most users should just use MarshalCanoto.
@@ -887,48 +919,39 @@ func (c *FieldType) MarshalCanotoInto(w Writer) Writer {
 		Append(&w, canoto__FieldType__OneOf__tag)
 		AppendBytes(&w, c.OneOf)
 	}
-	if !IsZero(c.TypeInt) {
+	switch c.CachedWhichOneOfType() {
+	case 6:
 		Append(&w, canoto__FieldType__TypeInt__tag)
 		AppendUint(&w, c.TypeInt)
-	}
-	if !IsZero(c.TypeUint) {
+	case 7:
 		Append(&w, canoto__FieldType__TypeUint__tag)
 		AppendUint(&w, c.TypeUint)
-	}
-	if !IsZero(c.TypeFixedInt) {
+	case 8:
 		Append(&w, canoto__FieldType__TypeFixedInt__tag)
 		AppendUint(&w, c.TypeFixedInt)
-	}
-	if !IsZero(c.TypeFixedUint) {
+	case 9:
 		Append(&w, canoto__FieldType__TypeFixedUint__tag)
 		AppendUint(&w, c.TypeFixedUint)
-	}
-	if !IsZero(c.TypeBool) {
+	case 10:
 		Append(&w, canoto__FieldType__TypeBool__tag)
 		AppendBool(&w, true)
-	}
-	if !IsZero(c.TypeString) {
+	case 11:
 		Append(&w, canoto__FieldType__TypeString__tag)
 		AppendBool(&w, true)
-	}
-	if !IsZero(c.TypeBytes) {
+	case 12:
 		Append(&w, canoto__FieldType__TypeBytes__tag)
 		AppendBool(&w, true)
-	}
-	if !IsZero(c.TypeFixedBytes) {
+	case 13:
 		Append(&w, canoto__FieldType__TypeFixedBytes__tag)
 		AppendUint(&w, c.TypeFixedBytes)
-	}
-	if !IsZero(c.TypeRecursive) {
+	case 14:
 		Append(&w, canoto__FieldType__TypeRecursive__tag)
 		AppendUint(&w, c.TypeRecursive)
-	}
-	if c.TypeMessage != nil {
-		if fieldSize := (c.TypeMessage).CachedCanotoSize(); fieldSize != 0 {
-			Append(&w, canoto__FieldType__TypeMessage__tag)
-			AppendUint(&w, fieldSize)
-			w = (c.TypeMessage).MarshalCanotoInto(w)
-		}
+	case 15:
+		fieldSize := (c.TypeMessage).CachedCanotoSize()
+		Append(&w, canoto__FieldType__TypeMessage__tag)
+		AppendUint(&w, fieldSize)
+		w = (c.TypeMessage).MarshalCanotoInto(w)
 	}
 	return w
 }

--- a/internal/canoto/canoto.canoto.go
+++ b/internal/canoto/canoto.canoto.go
@@ -3,9 +3,7 @@
 // 	canoto v0.17.1
 // source: canoto.go
 
-
 package canoto
-
 
 import (
 	"io"
@@ -13,26 +11,21 @@ import (
 	"sync/atomic"
 )
 
-
 // Ensure that unused imports do not error
 var (
 	_ atomic.Uint64
 
-
 	_ = io.ErrUnexpectedEOF
 )
-
 
 const (
 	canoto__Spec__Name__tag   = "\x0a" // canoto.Tag(1, canoto.Len)
 	canoto__Spec__Fields__tag = "\x12" // canoto.Tag(2, canoto.Len)
 )
 
-
 type canotoData_Spec struct {
 	size uint64
 }
-
 
 // CanotoSpec returns the specification of this canoto message.
 func (*Spec) CanotoSpec(types ...reflect.Type) *Spec {
@@ -62,12 +55,10 @@ func (*Spec) CanotoSpec(types ...reflect.Type) *Spec {
 	return s
 }
 
-
 // MakeCanoto creates a new empty value.
 func (*Spec) MakeCanoto() *Spec {
 	return new(Spec)
 }
-
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -78,7 +69,6 @@ func (c *Spec) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
-
 
 // UnmarshalCanotoFrom populates the struct from a [Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -91,7 +81,6 @@ func (c *Spec) UnmarshalCanotoFrom(r Reader) error {
 	*c = Spec{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
-
 	var minField uint32
 	for HasNext(&r) {
 		field, wireType, err := ReadTag(&r)
@@ -101,7 +90,6 @@ func (c *Spec) UnmarshalCanotoFrom(r Reader) error {
 		if field < minField {
 			return ErrInvalidFieldOrder
 		}
-
 
 		switch field {
 		case 1:
@@ -171,12 +159,10 @@ func (c *Spec) UnmarshalCanotoFrom(r Reader) error {
 			return ErrUnknownField
 		}
 
-
 		minField = field + 1
 	}
 	return nil
 }
-
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -203,7 +189,6 @@ func (c *Spec) ValidCanoto() bool {
 	return true
 }
 
-
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
 //
@@ -227,7 +212,6 @@ func (c *Spec) CalculateCanotoCache() {
 	atomic.StoreUint64(&c.canotoData.size, size)
 }
 
-
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -242,7 +226,6 @@ func (c *Spec) CachedCanotoSize() uint64 {
 	return atomic.LoadUint64(&c.canotoData.size)
 }
 
-
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -256,7 +239,6 @@ func (c *Spec) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
-
 
 // MarshalCanotoInto writes the struct into a [Writer] and returns the
 // resulting [Writer]. Most users should just use MarshalCanoto.
@@ -286,7 +268,6 @@ func (c *Spec) MarshalCanotoInto(w Writer) Writer {
 	return w
 }
 
-
 const (
 	canoto__FieldType__FieldNumber__tag    = "\x08" // canoto.Tag(1, canoto.Varint)
 	canoto__FieldType__Name__tag           = "\x12" // canoto.Tag(2, canoto.Len)
@@ -305,13 +286,11 @@ const (
 	canoto__FieldType__TypeMessage__tag    = "\x7a" // canoto.Tag(15, canoto.Len)
 )
 
-
 type canotoData_FieldType struct {
 	size uint64
 
 	TypeOneOf uint32
 }
-
 
 // CanotoSpec returns the specification of this canoto message.
 func (*FieldType) CanotoSpec(types ...reflect.Type) *Spec {
@@ -419,12 +398,10 @@ func (*FieldType) CanotoSpec(types ...reflect.Type) *Spec {
 	return s
 }
 
-
 // MakeCanoto creates a new empty value.
 func (*FieldType) MakeCanoto() *FieldType {
 	return new(FieldType)
 }
-
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -435,7 +412,6 @@ func (c *FieldType) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
-
 
 // UnmarshalCanotoFrom populates the struct from a [Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -448,7 +424,6 @@ func (c *FieldType) UnmarshalCanotoFrom(r Reader) error {
 	*c = FieldType{}
 	atomic.StoreUint64(&c.canotoData.size, uint64(len(r.B)))
 
-
 	var minField uint32
 	for HasNext(&r) {
 		field, wireType, err := ReadTag(&r)
@@ -458,7 +433,6 @@ func (c *FieldType) UnmarshalCanotoFrom(r Reader) error {
 		if field < minField {
 			return ErrInvalidFieldOrder
 		}
-
 
 		switch field {
 		case 1:
@@ -674,12 +648,10 @@ func (c *FieldType) UnmarshalCanotoFrom(r Reader) error {
 			return ErrUnknownField
 		}
 
-
 		minField = field + 1
 	}
 	return nil
 }
-
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -768,7 +740,6 @@ func (c *FieldType) ValidCanoto() bool {
 	return true
 }
 
-
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
 //
@@ -841,7 +812,6 @@ func (c *FieldType) CalculateCanotoCache() {
 	atomic.StoreUint32(&c.canotoData.TypeOneOf, TypeOneOf)
 }
 
-
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
 //
@@ -870,7 +840,6 @@ func (c *FieldType) CachedWhichOneOfType() uint32 {
 	return atomic.LoadUint32(&c.canotoData.TypeOneOf)
 }
 
-
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -884,7 +853,6 @@ func (c *FieldType) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
-
 
 // MarshalCanotoInto writes the struct into a [Writer] and returns the
 // resulting [Writer]. Most users should just use MarshalCanoto.

--- a/internal/inlined_canoto.canoto.go
+++ b/internal/inlined_canoto.canoto.go
@@ -3,9 +3,7 @@
 // 	canoto v0.17.1
 // source: inlined_canoto.go
 
-
 package examples
-
 
 import (
 	"io"
@@ -15,25 +13,20 @@ import (
 	"github.com/StephenButtolph/canoto/internal/canoto"
 )
 
-
 // Ensure that unused imports do not error
 var (
 	_ atomic.Uint64
 
-
 	_ = io.ErrUnexpectedEOF
 )
-
 
 const (
 	canoto__justAnInt__Int8__tag = "\x08" // canoto.Tag(1, canoto.Varint)
 )
 
-
 type canotoData_justAnInt struct {
 	size atomic.Uint64
 }
-
 
 // CanotoSpec returns the specification of this canoto message.
 func (*justAnInt) CanotoSpec(...reflect.Type) *canoto.Spec {
@@ -53,12 +46,10 @@ func (*justAnInt) CanotoSpec(...reflect.Type) *canoto.Spec {
 	return s
 }
 
-
 // MakeCanoto creates a new empty value.
 func (*justAnInt) MakeCanoto() *justAnInt {
 	return new(justAnInt)
 }
-
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -69,7 +60,6 @@ func (c *justAnInt) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
-
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -82,7 +72,6 @@ func (c *justAnInt) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = justAnInt{}
 	c.canotoData.size.Store(uint64(len(r.B)))
 
-
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -92,7 +81,6 @@ func (c *justAnInt) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
-
 
 		switch field {
 		case 1:
@@ -110,12 +98,10 @@ func (c *justAnInt) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
-
 		minField = field + 1
 	}
 	return nil
 }
-
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -131,7 +117,6 @@ func (c *justAnInt) ValidCanoto() bool {
 	return true
 }
 
-
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
 func (c *justAnInt) CalculateCanotoCache() {
@@ -144,7 +129,6 @@ func (c *justAnInt) CalculateCanotoCache() {
 	}
 	c.canotoData.size.Store(size)
 }
-
 
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
@@ -160,7 +144,6 @@ func (c *justAnInt) CachedCanotoSize() uint64 {
 	return c.canotoData.size.Load()
 }
 
-
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -172,7 +155,6 @@ func (c *justAnInt) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
-
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.

--- a/internal/inlined_canoto.canoto.go
+++ b/internal/inlined_canoto.canoto.go
@@ -3,7 +3,9 @@
 // 	canoto v0.17.1
 // source: inlined_canoto.go
 
+
 package examples
+
 
 import (
 	"io"
@@ -13,20 +15,25 @@ import (
 	"github.com/StephenButtolph/canoto/internal/canoto"
 )
 
+
 // Ensure that unused imports do not error
 var (
 	_ atomic.Uint64
 
+
 	_ = io.ErrUnexpectedEOF
 )
+
 
 const (
 	canoto__justAnInt__Int8__tag = "\x08" // canoto.Tag(1, canoto.Varint)
 )
 
+
 type canotoData_justAnInt struct {
 	size atomic.Uint64
 }
+
 
 // CanotoSpec returns the specification of this canoto message.
 func (*justAnInt) CanotoSpec(...reflect.Type) *canoto.Spec {
@@ -46,10 +53,12 @@ func (*justAnInt) CanotoSpec(...reflect.Type) *canoto.Spec {
 	return s
 }
 
+
 // MakeCanoto creates a new empty value.
 func (*justAnInt) MakeCanoto() *justAnInt {
 	return new(justAnInt)
 }
+
 
 // UnmarshalCanoto unmarshals a Canoto-encoded byte slice into the struct.
 //
@@ -60,6 +69,7 @@ func (c *justAnInt) UnmarshalCanoto(bytes []byte) error {
 	}
 	return c.UnmarshalCanotoFrom(r)
 }
+
 
 // UnmarshalCanotoFrom populates the struct from a [canoto.Reader]. Most users
 // should just use UnmarshalCanoto.
@@ -72,6 +82,7 @@ func (c *justAnInt) UnmarshalCanotoFrom(r canoto.Reader) error {
 	*c = justAnInt{}
 	c.canotoData.size.Store(uint64(len(r.B)))
 
+
 	var minField uint32
 	for canoto.HasNext(&r) {
 		field, wireType, err := canoto.ReadTag(&r)
@@ -81,6 +92,7 @@ func (c *justAnInt) UnmarshalCanotoFrom(r canoto.Reader) error {
 		if field < minField {
 			return canoto.ErrInvalidFieldOrder
 		}
+
 
 		switch field {
 		case 1:
@@ -98,10 +110,12 @@ func (c *justAnInt) UnmarshalCanotoFrom(r canoto.Reader) error {
 			return canoto.ErrUnknownField
 		}
 
+
 		minField = field + 1
 	}
 	return nil
 }
+
 
 // ValidCanoto validates that the struct can be correctly marshaled into the
 // Canoto format.
@@ -117,6 +131,7 @@ func (c *justAnInt) ValidCanoto() bool {
 	return true
 }
 
+
 // CalculateCanotoCache populates size and OneOf caches based on the current
 // values in the struct.
 func (c *justAnInt) CalculateCanotoCache() {
@@ -129,6 +144,7 @@ func (c *justAnInt) CalculateCanotoCache() {
 	}
 	c.canotoData.size.Store(size)
 }
+
 
 // CachedCanotoSize returns the previously calculated size of the Canoto
 // representation from CalculateCanotoCache.
@@ -144,6 +160,7 @@ func (c *justAnInt) CachedCanotoSize() uint64 {
 	return c.canotoData.size.Load()
 }
 
+
 // MarshalCanoto returns the Canoto representation of this struct.
 //
 // It is assumed that this struct is ValidCanoto.
@@ -155,6 +172,7 @@ func (c *justAnInt) MarshalCanoto() []byte {
 	w = c.MarshalCanotoInto(w)
 	return w.B
 }
+
 
 // MarshalCanotoInto writes the struct into a [canoto.Writer] and returns the
 // resulting [canoto.Writer]. Most users should just use MarshalCanoto.

--- a/internal/testdata/fuzz/FuzzScalars_Canonical/22a862591621028f
+++ b/internal/testdata/fuzz/FuzzScalars_Canonical/22a862591621028f
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("\xf2\x03\b008\xff\xff\xff\x800")


### PR DESCRIPTION
`MarshalCanotoInto` has a precondition that `CalculateCanotoCache` has been called already:

```
// It is assumed that CalculateCanotoCache has been called since the last
// modification to this struct.
```

We can then use a switch statement to marshal the oneof values.